### PR TITLE
introduce Travis CI to test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: java
+jdk: oraclejdk8
+sudo: false
+before_cache:
+  - rm -rf target/dictionary/*.zip
+cache:
+  directories:
+    - target/dictionary
+# Currently git-lfs has trouble, so skip downloading csv file from LFS.
+git:
+  lfs_skip_smudge: true
+# Currently `mvn package` cannot work due to git-lfs problem, see issue #1.
+# So we need to skip invoking `mvn install` for now.
+# https://docs.travis-ci.com/user/customizing-the-build#Skipping-the-Installation-Step
+install: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Sudachi
 
+[![Build Status](https://travis-ci.org/WorksApplications/Sudachi.svg?branch=use-large-java-heap-by-default)](https://travis-ci.org/WorksApplications/Sudachi)
+
 Sudachi is Japanese morphological analyzer. Morphological analysis consists
 mainly of the following tasks.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sudachi
 
-[![Build Status](https://travis-ci.org/WorksApplications/Sudachi.svg?branch=use-large-java-heap-by-default)](https://travis-ci.org/WorksApplications/Sudachi)
+[![Build Status](https://travis-ci.org/WorksApplications/Sudachi.svg?branch=develop)](https://travis-ci.org/WorksApplications/Sudachi)
 
 Sudachi is Japanese morphological analyzer. Morphological analysis consists
 mainly of the following tasks.


### PR DESCRIPTION
CI is one of the best practices for developers, to keep better velocity and quality. I think Travis CI is really great so I suggest you to use it.

This PR just proposes to introduce build before/after merge, but if you need, it also helps you to:

- Deploy latest artifacts to Maven repository like [Sonatype snapshot repository](https://oss.sonatype.org/content/repositories/snapshots/).
- Deploy latest javadoc to GitHub pages, in your case https://worksapplications.github.io/Sudachi/
- Analyse changes in PR by [SonarQube](https://sonarcloud.io/), to find potential problem before merge.
- Deploy stable artifacts and javadoc, when you tag a commit.
- etc.