### PR TITLE
Reproduce problem by JUnit, and fix it

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,6 +210,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish</groupId>
       <artifactId>javax.json</artifactId>
       <version>1.1</version>

--- a/src/main/java/com/worksap/nlp/sudachi/UTF8InputText.java
+++ b/src/main/java/com/worksap/nlp/sudachi/UTF8InputText.java
@@ -91,7 +91,7 @@ class UTF8InputText implements InputText<byte[]> {
     
     @Override
     public Set<CategoryType> getCharCategoryTypes(int index) {
-        return charCategories.get(byteIndexes[index]);
+        return charCategories.get(byteIndexes[index]).clone();
     }
     
     @Override

--- a/src/main/java/com/worksap/nlp/sudachi/UTF8InputText.java
+++ b/src/main/java/com/worksap/nlp/sudachi/UTF8InputText.java
@@ -91,7 +91,14 @@ class UTF8InputText implements InputText<byte[]> {
     
     @Override
     public Set<CategoryType> getCharCategoryTypes(int index) {
-        return charCategories.get(byteIndexes[index]).clone();
+        if (index < 0 || byteIndexes.length <= index) {
+            String message = String.format("Index should be zero or positive value less than %d, but was %d", byteIndexes.length, index);
+            throw new IllegalArgumentException(message);
+        }
+        int byteIndex = byteIndexes[index];
+        assert 0 <= byteIndex;
+        assert byteIndex < charCategories.size();
+        return charCategories.get(byteIndex).clone();
     }
     
     @Override
@@ -111,6 +118,10 @@ class UTF8InputText implements InputText<byte[]> {
 
     @Override
     public int getCharCategoryContinuousLength(int index) {
+        if (index < 0 || charCategoryContinuities.size() <= index) {
+            String message = String.format("Index should be zero or positive value less than %d, but was %d", charCategoryContinuities.size(), index);
+            throw new IllegalArgumentException(message);
+        }
         return charCategoryContinuities.get(index);
     }
     

--- a/src/test/java/com/worksap/nlp/sudachi/UTF8InputTextTest.java
+++ b/src/test/java/com/worksap/nlp/sudachi/UTF8InputTextTest.java
@@ -252,6 +252,14 @@ public class UTF8InputTextTest {
         assertTrue(input.canBow(23)); // ア
     }
 
+    @Test
+    public void returnedSetShouldNotExposureInternalData() {
+        input = builder.build();
+        assertThat(input.getCharCategoryTypes(0), hasItem(CategoryType.ALPHA));
+        input.getCharCategoryTypes(0).clear();
+        assertThat(input.getCharCategoryTypes(0), hasItem(CategoryType.ALPHA));
+    }
+
     class MockGrammar implements Grammar {
         @Override
         public int getPartOfSpeechSize() {

--- a/src/test/java/com/worksap/nlp/sudachi/UTF8InputTextTest.java
+++ b/src/test/java/com/worksap/nlp/sudachi/UTF8InputTextTest.java
@@ -18,6 +18,7 @@ package com.worksap.nlp.sudachi;
 
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.empty;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -27,14 +28,18 @@ import java.io.IOException;
 import java.util.List;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import com.worksap.nlp.sudachi.dictionary.CategoryType;
 import com.worksap.nlp.sudachi.dictionary.CharacterCategory;
 import com.worksap.nlp.sudachi.dictionary.Grammar;
 
 public class UTF8InputTextTest {
-    
+    @Rule
+    public ExpectedException expected = ExpectedException.none();
+
     // mixed full-width, half-width, accented
     // U+2123D '𡈽' uses surrogate pair
     static final String TEXT = "âｂC1あ234漢字𡈽アｺﾞ";
@@ -250,6 +255,52 @@ public class UTF8InputTextTest {
         assertFalse(input.canBow(21));
         assertFalse(input.canBow(22));
         assertTrue(input.canBow(23)); // ア
+    }
+
+    @Test
+    public void testGetCharCategoryContinuousLengthWithNegativeIndex() {
+        input = builder.build();
+        expected.expect(IllegalArgumentException.class);
+        expected.expectMessage("Index should be zero or positive value less than 32, but was -1");
+        input.getCharCategoryContinuousLength(-1);
+    }
+
+    @Test
+    public void testGetCharCategoryContinuousLengthWithTooLargeIndex() {
+        input = builder.build();
+        expected.expect(IllegalArgumentException.class);
+        expected.expectMessage("Index should be zero or positive value less than 32, but was 32");
+        input.getCharCategoryContinuousLength(32);
+    }
+
+    @Test
+    public void testGetCharCategoryTypesWithNegativeIndex() {
+        input = builder.build();
+        expected.expect(IllegalArgumentException.class);
+        expected.expectMessage("Index should be zero or positive value less than 33, but was -1");
+        input.getCharCategoryTypes(-1);
+    }
+
+    @Test
+    public void testGetCharCategoryTypesWithTooLargeIndex() {
+        input = builder.build();
+        expected.expect(IllegalArgumentException.class);
+        expected.expectMessage("Index should be zero or positive value less than 33, but was 33");
+        input.getCharCategoryTypes(33);
+    }
+
+    @Test
+    public void testGetCharCategoryTypesWithNegativeIndex2() {
+        input = builder.build();
+        expected.expect(IllegalArgumentException.class);
+        expected.expectMessage("Index should be zero or positive value less than 32, but was -1");
+        input.getCharCategoryTypes(-1, 1);
+    }
+
+    @Test
+    public void testGetCharCategoryTypesWithTooLargeIndex2() {
+        input = builder.build();
+        assertThat(input.getCharCategoryTypes(0, 32), is(empty()));
     }
 
     @Test


### PR DESCRIPTION
Here is suggestion to enhance both test code and implementation. This also improve test coverage a little.

* A bug reproduced by c90f68c6685f81d31f34577c4e0610a92c87726e, means that, returned `EnumSet` exposures internal data of `UTF8InputText` class. This bug should be fixed I think.
* Bugs reproduced by 30f7ba247bc4f262f7b5ae4159437e75af05d99a, are not mandatory, but makes error message intuitive.