### PR TITLE
Enhance build & README

### DIFF
--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -6,11 +6,16 @@ Sudachi is Japanese morphological analyzer.
 1. Build and install Sudachi
 2. Copy files
 
-   $ cp ../src/main/resources/*.def src/test/resources/com/worksap/nlp/lucene/sudachi/ja
-   $ cp ../target/system.dic src/test/resources/com/worksap/nlp/lucene/sudachi/ja
+    ```sh
+    $ cp ../src/main/resources/*.def src/test/resources/com/worksap/nlp/lucene/sudachi/ja
+    $ cp ../target/system.dic src/test/resources/com/worksap/nlp/lucene/sudachi/ja
+    ```
+
 3. Build
 
+    ```sh
    $ mvn package
+   ```
 
 # Installation
 
@@ -26,17 +31,17 @@ Sudachi is Japanese morphological analyzer.
 - settings\_path: Sudachi setting file path. The path may be absolute or relative; relative paths are resolved with respect to ES\_HOME. (string, default: null)  
 - resources_path: Sudachi dictionary path. The path may be absolute or relative; relative paths are resolved with respect to ES\_HOME. (string, default: null)  
 
-**[Example]** 
+**[Example]**
 
     "tokenizer": {
-        "mytokenizer": {
-		"type": "sudachi_tokenizer",
-		"mode": "search",
-		"discard_punctuation": true,
-		"settings_path": "sudachiSettings.json",
-		"resources_path": "config"
-         }
-      } 
+      "mytokenizer": {
+        "type": "sudachi_tokenizer",
+        "mode": "search",
+        "discard_punctuation": true,
+        "settings_path": "sudachiSettings.json",
+        "resources_path": "config"
+      }
+    }
 
 # Corresponding Filter
 - sudachi\_part\_of\_speech: Exclude the specified part of speech.  
@@ -48,7 +53,7 @@ Sudachi is Japanese morphological analyzer.
 Copyright (c) 2017 Works Applications Co., Ltd.  
 Originally under elasticsearch, https://www.elastic.co/jp/products/elasticsearch  
 Originally under lucene, https://lucene.apache.org/
- 
+
 # Sudachi
 Sudachi は日本語用の形態素解析器です。
 
@@ -57,11 +62,16 @@ Sudachi は日本語用の形態素解析器です。
 1. Sudachi をビルドし、インストールします
 2. Sudachi の構成ファイルをコピーします
 
-   $ cp ../src/main/resources/*.def src/test/resources/com/worksap/nlp/lucene/sudachi/ja
-   $ cp ../target/system.dic src/test/resources/com/worksap/nlp/lucene/sudachi/ja
+    ```sh
+    $ cp ../src/main/resources/*.def src/test/resources/com/worksap/nlp/lucene/sudachi/ja
+    $ cp ../target/system.dic src/test/resources/com/worksap/nlp/lucene/sudachi/ja
+    ```
+
 3. プラグインをビルドします
 
-   $ mvn package
+    ```sh
+    $ mvn package
+    ```
 
 # インストール方法
 
@@ -76,17 +86,17 @@ Sudachi は日本語用の形態素解析器です。
 - settings\_path: Sudachiの設定ファイルが配置されているファイルパスを設定します。絶対パス、相対パスともに設定可能です。相対パスの場合はES\_HOMEを基準にします。(string, default: null)  
 - resources_path: Sudachiで利用する辞書ファイルのディクショナリパスを設定します。絶対パス、相対パスともに設定可能です。相対パスの場合はES\_HOMEを基準にします。(string, default: null)  
 
-**[例]** 
+**[例]**
 
     "tokenizer": {
-        "mytokenizer": {
-		"type": "sudachi_tokenizer",
-		"mode": "search",
-		"discard_punctuation": true,
-		"settings_path": "sudachiSettings.json",
-		"resources_path": "config"
-         }
-      } 
+      "mytokenizer": {
+        "type": "sudachi_tokenizer",
+        "mode": "search",
+        "discard_punctuation": true,
+        "settings_path": "sudachiSettings.json",
+        "resources_path": "config"
+      }
+    }
 
 # 対応フィルター
 - sudachi\_part\_of\_speech: テキスト分割された結果から特定の品詞を排除することができます。  

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -13,6 +13,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
+		<elasticsearch.version>5.6.1</elasticsearch.version>
 	</properties>
 
 	<build>
@@ -57,7 +58,7 @@
 		</plugins>
 	</build>
 	<dependencies>
-	   <!-- Sudachi -->    
+	   <!-- Sudachi -->
 		<dependency>
 			<groupId>com.worksap.nlp</groupId>
 			<artifactId>sudachi</artifactId>
@@ -67,7 +68,7 @@
 		<dependency>
 			<groupId>org.elasticsearch.client</groupId>
 			<artifactId>transport</artifactId>
-			<version>5.6.1</version>
+			<version>${elasticsearch.version}</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.apache.lucene/lucene-analyzers-kuromoji -->
 		<dependency>
@@ -109,7 +110,7 @@
 		<dependency>
 			<groupId>org.elasticsearch.test</groupId>
 			<artifactId>framework</artifactId>
-			<version>5.6.1</version>
+			<version>${elasticsearch.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/elasticsearch/src/main/extras/plugin-descriptor.properties
+++ b/elasticsearch/src/main/extras/plugin-descriptor.properties
@@ -67,12 +67,12 @@ java.version=1.8
 # elasticsearch release. This version is checked when the plugin
 # is loaded so Elasticsearch will refuse to start in the presence of
 # plugins with the incorrect elasticsearch.version.
-elasticsearch.version=5.6.1
+elasticsearch.version=${elasticsearch.version}
 #
 ### deprecated elements for jvm plugins :
 #
 # 'isolated': true if the plugin should have its own classloader.
-# passing false is deprecated, and only intended to support plugins 
+# passing false is deprecated, and only intended to support plugins
 # that have hard dependencies against each other. If this is
 # not specified, then the plugin is isolated by default.
 isolated=true


### PR DESCRIPTION
1. Manage version of supported Elasticsearch by Maven property
    * It helps us to build easily with different version, e.g. `mvn verify -Delasticsearch.version=foo`
2. Fix broken format in `elasticsearch/README.md`