### PR TITLE
Replace container-based VM with sudo-enabled VM to use more memory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: java
 jdk: oraclejdk8
-sudo: false
+# To use 7.5GiB memory, specify 'required' for 'sudo'
+# https://docs.travis-ci.com/user/reference/overview/#Virtualization-environments
+sudo: required
+dist: trusty
 env:
   global:
     # GITHUB_TOKEN


### PR DESCRIPTION
Our Maven process requires 4GiB JVM memory, but Container based VM has only 4 GiB memory so it's not enough.
We should use sudo-enabled VM which has 7.5 GiB memory.

I confirmed that deploy script can run successfully by [this build job](https://travis-ci.org/WorksApplications/Sudachi/builds/299654900).