### PR TITLE
release system.dic as an artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,16 +160,27 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <configuration>
-          <descriptor>src/assembly/bin.xml</descriptor>
-          <finalName>sudachi-${project.version}</finalName>
-        </configuration>
         <executions>
           <execution>
             <phase>package</phase>
             <goals>
               <goal>single</goal>
             </goals>
+            <configuration>
+              <descriptor>src/assembly/bin.xml</descriptor>
+              <finalName>sudachi-${project.version}</finalName>
+            </configuration>
+          </execution>
+          <execution>
+            <id>assemble-dictionary</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <descriptor>src/assembly/dic.xml</descriptor>
+              <finalName>sudachi-dictionary-${project.version}</finalName>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/src/assembly/dic.xml
+++ b/src/assembly/dic.xml
@@ -6,6 +6,10 @@
     <format>zip</format>
     <format>tar.bz2</format>
   </formats>
+  <!--
+    maven-dependency-plugin:unpack does not support flatten directory structure at extraction phase,
+    so this is necessary to unpack single file without its parent directory.
+  -->
   <includeBaseDirectory>false</includeBaseDirectory>
   <fileSets>
     <fileSet>

--- a/src/assembly/dic.xml
+++ b/src/assembly/dic.xml
@@ -1,0 +1,19 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+  <id>dictionary</id>
+  <formats>
+    <format>zip</format>
+    <format>tar.bz2</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>target</directory>
+      <outputDirectory>/</outputDirectory>
+      <includes>
+        <include>system.dic</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+</assembly>


### PR DESCRIPTION
Currently user of system.dic needs a complicated hack like https://github.com/WorksApplications/elasticsearch-sudachi/pull/1/.
To make their build script enough simple, then user can simplify their build config like https://github.com/WorksApplications/elasticsearch-sudachi/pull/6.