### PR TITLE
Use batch mode to reduce deploy progress log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ after_success:
 deploy:
   - provider: script
     # To build SNAPSHOT packages with CSV file, we need to fetch & checkout by git-lfs
-    script: git lfs fetch && git lfs checkout && mvn deploy --settings .travis/settings.xml
+    script: git lfs fetch && git lfs checkout && mvn deploy -B --settings .travis/settings.xml
     # Skip cleanup to keep decrepted .travis/settings.xml in workspace
     # https://docs.travis-ci.com/user/deployment/
     skip_cleanup: true


### PR DESCRIPTION
Currently deployment phase generates 3.9MiB log, because we do not use `-B` option when we trigger `mvn deploy`.
This change will reduce size of log, and make the build stable.