### PR TITLE
"Prolonged Sound Mark" Normalization Plugin

### DIFF
--- a/src/main/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPlugin.java
+++ b/src/main/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPlugin.java
@@ -19,6 +19,7 @@ package com.worksap.nlp.sudachi;
         import java.io.IOException;
         import java.util.HashSet;
         import java.util.Set;
+        import java.util.List;
 
 /**
  * A plugin that rewrites the Katakana-Hiragana Prolonged Sound Mark (Chōonpu) and similar symbols.
@@ -32,8 +33,15 @@ package com.worksap.nlp.sudachi;
  * <pre>{@code
  *   {
  *     "class" : "com.worksap.nlp.sudachi.ProlongedSoundMarkInputTextPlugin",
+        "prolongedSoundMarks": ["ー", "〜", "〰"],
+        "replacementSymbol": "ー"
  *   }
  * }</pre>
+ *
+ * {@code prolongedSoundMarks} is the list of symbols to be combined.
+ * {@code replacementSymbol} is the symbol for replacement, after combining prolonged sound mark sequences.
+ *
+ * <p>With above setting example, the plugin rewrites input "エーービ〜〜〜シ〰〰〰〰" to "エービーシー".
  */
 class ProlongedSoundMarkTextPlugin extends InputTextPlugin {
 
@@ -42,10 +50,11 @@ class ProlongedSoundMarkTextPlugin extends InputTextPlugin {
 
     @Override
     public void setUp() throws IOException {
-        prolongedSoundMarkSet.add("ー".codePointAt(0));
-        prolongedSoundMarkSet.add("〜".codePointAt(0));
-        prolongedSoundMarkSet.add("〰".codePointAt(0));
-        replacementSymbol = "ー";
+        List<String> prolongedSoundMarkStrings = settings.getStringList("prolongedSoundMarks");
+        for (String s : prolongedSoundMarkStrings) {
+            prolongedSoundMarkSet.add(s.codePointAt(0));
+        }
+        replacementSymbol = settings.getString("replacementSymbol");
     }
 
     @Override

--- a/src/main/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPlugin.java
+++ b/src/main/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPlugin.java
@@ -42,6 +42,7 @@ class ProlongedSoundMarkTextPlugin extends InputTextPlugin {
         String text = builder.getText();
 
         int n = text.length();
+        int offset = 0;
         int markStartIndex = n;
         boolean isProlongedSoundMark = false;
         for (int i = 0; i < n; i++) {
@@ -52,13 +53,14 @@ class ProlongedSoundMarkTextPlugin extends InputTextPlugin {
             }
             else if (isProlongedSoundMark && c != prolongedSoundMark) {
                 if ((i - markStartIndex) > 1) {
-                    builder.replace(markStartIndex, i, "ー");
+                    builder.replace(markStartIndex-offset, i-offset, "ー");
+                    offset += i - markStartIndex - 1;
                 }
                 isProlongedSoundMark = false;
             }
         }
         if (isProlongedSoundMark && (n - markStartIndex) > 1) {
-            builder.replace(markStartIndex, n, "ー");
+            builder.replace(markStartIndex-offset, n-offset, "ー");
         }
     }
 }

--- a/src/main/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPlugin.java
+++ b/src/main/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPlugin.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2017 Works Applications Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.worksap.nlp.sudachi;
+
+        import java.util.Set;
+
+/**
+ * A plugin that rewrites the Katakana-Hiragana Prolonged Sound Mark (Chōonpu) and similar symbols.
+ *
+ * <p>This plugin shrinks the continuous sequence of prolonged sound marks to 1 character.
+ *
+ * <p>{@link Dictionary} initialize this plugin with {@link Settings}.
+ * It can be refered as {@link Plugin#settings}.
+ *
+ * <p>The following is an example of settings.
+ * <pre>{@code
+ *   {
+ *     "class" : "com.worksap.nlp.sudachi.ProlongedSoundMarkInputTextPlugin",
+ *   }
+ * }</pre>
+ */
+class ProlongedSoundMarkTextPlugin extends InputTextPlugin {
+
+    char prolongedSoundMark = 'ー';
+
+    @Override
+    public void rewrite(InputTextBuilder<?> builder) {
+        String text = builder.getText();
+        for (int i = 0; i < text.length(); i++) {
+            char c = text.charAt(i);
+            if (c != prolongedSoundMark) {
+                continue;
+            }
+            else {
+                int j = i;
+                while (c == prolongedSoundMark) {
+                    j += 1;
+                    c = text.charAt(j);
+                }
+                builder.replace(i, j, "ー");
+                i = j;
+            }
+        }
+    }
+}

--- a/src/main/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPlugin.java
+++ b/src/main/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPlugin.java
@@ -16,6 +16,8 @@
 
 package com.worksap.nlp.sudachi;
 
+        import java.io.IOException;
+        import java.util.HashSet;
         import java.util.Set;
 
 /**
@@ -35,7 +37,16 @@ package com.worksap.nlp.sudachi;
  */
 class ProlongedSoundMarkTextPlugin extends InputTextPlugin {
 
-    char prolongedSoundMark = 'ー';
+    private Set<Integer> prolongedSoundMarkSet = new HashSet<>();
+    private String replacementSymbol;
+
+    @Override
+    public void setUp() throws IOException {
+        prolongedSoundMarkSet.add("ー".codePointAt(0));
+        prolongedSoundMarkSet.add("〜".codePointAt(0));
+        prolongedSoundMarkSet.add("〰".codePointAt(0));
+        replacementSymbol = "ー";
+    }
 
     @Override
     public void rewrite(InputTextBuilder<?> builder) {
@@ -46,21 +57,21 @@ class ProlongedSoundMarkTextPlugin extends InputTextPlugin {
         int markStartIndex = n;
         boolean isProlongedSoundMark = false;
         for (int i = 0; i < n; i++) {
-            char c = text.charAt(i);
-            if (!isProlongedSoundMark && c == prolongedSoundMark) {
+            int cp = text.codePointAt(i);
+            if (!isProlongedSoundMark && prolongedSoundMarkSet.contains(cp)) {
                 isProlongedSoundMark = true;
                 markStartIndex = i;
             }
-            else if (isProlongedSoundMark && c != prolongedSoundMark) {
+            else if (isProlongedSoundMark && !prolongedSoundMarkSet.contains(cp)) {
                 if ((i - markStartIndex) > 1) {
-                    builder.replace(markStartIndex-offset, i-offset, "ー");
+                    builder.replace(markStartIndex-offset, i-offset, replacementSymbol);
                     offset += i - markStartIndex - 1;
                 }
                 isProlongedSoundMark = false;
             }
         }
         if (isProlongedSoundMark && (n - markStartIndex) > 1) {
-            builder.replace(markStartIndex-offset, n-offset, "ー");
+            builder.replace(markStartIndex-offset, n-offset, replacementSymbol);
         }
     }
 }

--- a/src/main/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPlugin.java
+++ b/src/main/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPlugin.java
@@ -51,11 +51,13 @@ class ProlongedSoundMarkTextPlugin extends InputTextPlugin {
                 markStartIndex = i;
             }
             else if (isProlongedSoundMark && c != prolongedSoundMark) {
-                builder.replace(markStartIndex, i, "ー");
+                if ((i - markStartIndex) > 1) {
+                    builder.replace(markStartIndex, i, "ー");
+                }
                 isProlongedSoundMark = false;
             }
         }
-        if (isProlongedSoundMark) {
+        if (isProlongedSoundMark && (n - markStartIndex) > 1) {
             builder.replace(markStartIndex, n, "ー");
         }
     }

--- a/src/main/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPlugin.java
+++ b/src/main/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPlugin.java
@@ -43,7 +43,7 @@ package com.worksap.nlp.sudachi;
  *
  * <p>With above setting example, the plugin rewrites input "エーービ〜〜〜シ〰〰〰〰" to "エービーシー".
  */
-class ProlongedSoundMarkTextPlugin extends InputTextPlugin {
+class ProlongedSoundMarkInputTextPlugin extends InputTextPlugin {
 
     private Set<Integer> prolongedSoundMarkSet = new HashSet<>();
     private String replacementSymbol;

--- a/src/main/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPlugin.java
+++ b/src/main/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPlugin.java
@@ -21,10 +21,10 @@ package com.worksap.nlp.sudachi;
 /**
  * A plugin that rewrites the Katakana-Hiragana Prolonged Sound Mark (Chōonpu) and similar symbols.
  *
- * <p>This plugin shrinks the continuous sequence of prolonged sound marks to 1 character.
+ * <p>This plugin combines the continuous sequence of prolonged sound marks to 1 character.
  *
  * <p>{@link Dictionary} initialize this plugin with {@link Settings}.
- * It can be refered as {@link Plugin#settings}.
+ * It can be referred as {@link Plugin#settings}.
  *
  * <p>The following is an example of settings.
  * <pre>{@code
@@ -40,20 +40,23 @@ class ProlongedSoundMarkTextPlugin extends InputTextPlugin {
     @Override
     public void rewrite(InputTextBuilder<?> builder) {
         String text = builder.getText();
-        for (int i = 0; i < text.length(); i++) {
+
+        int n = text.length();
+        int markStartIndex = n;
+        boolean isProlongedSoundMark = false;
+        for (int i = 0; i < n; i++) {
             char c = text.charAt(i);
-            if (c != prolongedSoundMark) {
-                continue;
+            if (!isProlongedSoundMark && c == prolongedSoundMark) {
+                isProlongedSoundMark = true;
+                markStartIndex = i;
             }
-            else {
-                int j = i;
-                while (c == prolongedSoundMark) {
-                    j += 1;
-                    c = text.charAt(j);
-                }
-                builder.replace(i, j, "ー");
-                i = j;
+            else if (isProlongedSoundMark && c != prolongedSoundMark) {
+                builder.replace(markStartIndex, i, "ー");
+                isProlongedSoundMark = false;
             }
+        }
+        if (isProlongedSoundMark) {
+            builder.replace(markStartIndex, n, "ー");
         }
     }
 }

--- a/src/main/resources/sudachi.json
+++ b/src/main/resources/sudachi.json
@@ -4,7 +4,7 @@
     "inputTextPlugin" : [
         { "class" : "com.worksap.nlp.sudachi.DefaultInputTextPlugin" },
         { "class" : "com.worksap.nlp.sudachi.ProlongedSoundMarkInputTextPlugin",
-          "prolongedSoundMarks": ["ー", "—", "―", "─", "━", "-", "－", "ｰ", "⁓", "~", "〜", "〰"],
+          "prolongedSoundMarks": ["ー", "-", "⁓", "〜", "〰"],
           "replacementSymbol": "ー"}
     ],
     "oovProviderPlugin" : [

--- a/src/main/resources/sudachi.json
+++ b/src/main/resources/sudachi.json
@@ -2,7 +2,10 @@
     "systemDict" : "system_core.dic",
     "characterDefinitionFile" : "char.def",
     "inputTextPlugin" : [
-        { "class" : "com.worksap.nlp.sudachi.DefaultInputTextPlugin" }
+        { "class" : "com.worksap.nlp.sudachi.DefaultInputTextPlugin" },
+        { "class" : "com.worksap.nlp.sudachi.ProlongedSoundMarkInputTextPlugin",
+          "prolongedSoundMarks": ["ー", "—", "―", "─", "━", "-", "－", "ｰ", "⁓", "~", "〜", "〰"],
+          "replacementSymbol": "ー"}
     ],
     "oovProviderPlugin" : [
         { "class" : "com.worksap.nlp.sudachi.MeCabOovProviderPlugin",

--- a/src/test/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPluginTest.java
+++ b/src/test/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPluginTest.java
@@ -23,6 +23,8 @@ import static org.junit.Assert.assertThat;
 import java.io.IOException;
 import java.util.List;
 
+import javax.json.JsonObject;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -36,8 +38,19 @@ public class ProlongedSoundMarkInputTextPluginTest {
     ProlongedSoundMarkTextPlugin plugin;
     
     @Before
-    public void setUp() {
+    public void setUp() throws IOException {
         plugin = new ProlongedSoundMarkTextPlugin();
+
+        String jsonString = Utils.readAllResource("/sudachi.json");
+        Settings settings = Settings.parseSettings(null, jsonString);
+        List<JsonObject> list = settings.getList("inputTextPlugin", JsonObject.class);
+        for (JsonObject p : list) {
+            if (p.getString("class").equals("com.worksap.nlp.sudachi.ProlongedSoundMarkInputTextPlugin")) {
+                plugin.setSettings(new Settings(p, null));
+                break;
+            }
+        }
+
         try {
             plugin.setUp();
         }

--- a/src/test/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPluginTest.java
+++ b/src/test/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPluginTest.java
@@ -99,8 +99,8 @@ public class ProlongedSoundMarkInputTextPluginTest {
 
     @Test
     public void combineContinuousProlongedSoundMarksMultipleTimes() {
-        final String ORIGINAL_TEXT = "スーーーパーーーーー";
-        final String NORMALIZED_TEXT = "スーパー";
+        final String ORIGINAL_TEXT = "エーービーーーシーーーー";
+        final String NORMALIZED_TEXT = "エービーシー";
         builder = new UTF8InputTextBuilder(ORIGINAL_TEXT, new MockGrammar());
         plugin.rewrite(builder);
         text = builder.build();
@@ -108,19 +108,23 @@ public class ProlongedSoundMarkInputTextPluginTest {
         assertThat(text.getOriginalText(), is(ORIGINAL_TEXT));
         assertThat(text.getText(), is(NORMALIZED_TEXT));
         byte[] bytes = text.getByteText();
-        assertThat(bytes.length, is(12));
+        assertThat(bytes.length, is(18));
         assertArrayEquals(
                 new byte[] {
-                        (byte)0xE3, (byte)0x82, (byte)0xB9, (byte)0xE3,
+                        (byte)0xE3, (byte)0x82, (byte)0xA8, (byte)0xE3,
                         (byte)0x83, (byte)0xBC, (byte)0xE3, (byte)0x83,
-                        (byte)0x91, (byte)0xE3, (byte)0x83, (byte)0xBC
+                        (byte)0x93, (byte)0xE3, (byte)0x83, (byte)0xBC,
+                        (byte)0xE3, (byte)0x82, (byte)0xB7, (byte)0xE3,
+                        (byte)0x83, (byte)0xBC
                 }, bytes
         );
         assertThat(text.getOriginalIndex(0), is(0));
         assertThat(text.getOriginalIndex(3), is(1));
-        assertThat(text.getOriginalIndex(6), is(4));
-        assertThat(text.getOriginalIndex(9), is(5));
-        assertThat(text.getOriginalIndex(12), is(10));
+        assertThat(text.getOriginalIndex(6), is(3));
+        assertThat(text.getOriginalIndex(9), is(4));
+        assertThat(text.getOriginalIndex(12), is(7));
+        assertThat(text.getOriginalIndex(15), is(8));
+        assertThat(text.getOriginalIndex(18), is(12));
     }
 
     class MockGrammar implements Grammar {

--- a/src/test/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPluginTest.java
+++ b/src/test/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPluginTest.java
@@ -35,11 +35,11 @@ public class ProlongedSoundMarkInputTextPluginTest {
     
     UTF8InputTextBuilder builder;
     UTF8InputText text;
-    ProlongedSoundMarkTextPlugin plugin;
+    ProlongedSoundMarkInputTextPlugin plugin;
     
     @Before
     public void setUp() throws IOException {
-        plugin = new ProlongedSoundMarkTextPlugin();
+        plugin = new ProlongedSoundMarkInputTextPlugin();
 
         String jsonString = Utils.readAllResource("/sudachi.json");
         Settings settings = Settings.parseSettings(null, jsonString);

--- a/src/test/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPluginTest.java
+++ b/src/test/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPluginTest.java
@@ -97,6 +97,32 @@ public class ProlongedSoundMarkInputTextPluginTest {
         assertThat(text.getOriginalIndex(12), is(6));
     }
 
+    @Test
+    public void combineContinuousProlongedSoundMarksMultipleTypes() {
+        final String ORIGINAL_TEXT = "スーーーパーーーーー";
+        final String NORMALIZED_TEXT = "スーパー";
+        builder = new UTF8InputTextBuilder(ORIGINAL_TEXT, new MockGrammar());
+        plugin.rewrite(builder);
+        text = builder.build();
+
+        assertThat(text.getOriginalText(), is(ORIGINAL_TEXT));
+        assertThat(text.getText(), is(NORMALIZED_TEXT));
+        byte[] bytes = text.getByteText();
+        assertThat(bytes.length, is(12));
+        assertArrayEquals(
+                new byte[] {
+                        (byte)0xE3, (byte)0x82, (byte)0xB9, (byte)0xE3,
+                        (byte)0x83, (byte)0xBC, (byte)0xE3, (byte)0x83,
+                        (byte)0x91, (byte)0xE3, (byte)0x83, (byte)0xBC
+                }, bytes
+        );
+        assertThat(text.getOriginalIndex(0), is(0));
+        assertThat(text.getOriginalIndex(3), is(1));
+        assertThat(text.getOriginalIndex(6), is(4));
+        assertThat(text.getOriginalIndex(9), is(5));
+        assertThat(text.getOriginalIndex(12), is(10));
+    }
+
     class MockGrammar implements Grammar {
         @Override
         public int getPartOfSpeechSize() {

--- a/src/test/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPluginTest.java
+++ b/src/test/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPluginTest.java
@@ -98,7 +98,7 @@ public class ProlongedSoundMarkInputTextPluginTest {
     }
 
     @Test
-    public void combineContinuousProlongedSoundMarksMultipleTypes() {
+    public void combineContinuousProlongedSoundMarksMultipleTimes() {
         final String ORIGINAL_TEXT = "スーーーパーーーーー";
         final String NORMALIZED_TEXT = "スーパー";
         builder = new UTF8InputTextBuilder(ORIGINAL_TEXT, new MockGrammar());

--- a/src/test/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPluginTest.java
+++ b/src/test/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPluginTest.java
@@ -71,6 +71,32 @@ public class ProlongedSoundMarkInputTextPluginTest {
         assertThat(text.getOriginalIndex(9), is(7));
     }
 
+    @Test
+    public void combineContinuousProlongedSoundMarksAtEnd() {
+        final String ORIGINAL_TEXT = "スーパーーー";
+        final String NORMALIZED_TEXT = "スーパー";
+        builder = new UTF8InputTextBuilder(ORIGINAL_TEXT, new MockGrammar());
+        plugin.rewrite(builder);
+        text = builder.build();
+
+        assertThat(text.getOriginalText(), is(ORIGINAL_TEXT));
+        assertThat(text.getText(), is(NORMALIZED_TEXT));
+        byte[] bytes = text.getByteText();
+        assertThat(bytes.length, is(12));
+        assertArrayEquals(
+                new byte[] {
+                        (byte)0xE3, (byte)0x82, (byte)0xB9, (byte)0xE3,
+                        (byte)0x83, (byte)0xBC, (byte)0xE3, (byte)0x83,
+                        (byte)0x91, (byte)0xE3, (byte)0x83, (byte)0xBC
+                }, bytes
+        );
+        assertThat(text.getOriginalIndex(0), is(0));
+        assertThat(text.getOriginalIndex(3), is(1));
+        assertThat(text.getOriginalIndex(6), is(2));
+        assertThat(text.getOriginalIndex(9), is(3));
+        assertThat(text.getOriginalIndex(12), is(6));
+    }
+
     class MockGrammar implements Grammar {
         @Override
         public int getPartOfSpeechSize() {

--- a/src/test/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPluginTest.java
+++ b/src/test/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPluginTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2017 Works Applications Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.worksap.nlp.sudachi;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.worksap.nlp.sudachi.dictionary.CharacterCategory;
+import com.worksap.nlp.sudachi.dictionary.Grammar;
+
+public class ProlongedSoundMarkInputTextPluginTest {
+    
+    static final String ORIGINAL_TEXT = "ゴーーーーール";
+    static final String NORMALIZED_TEXT = "ゴール";
+    UTF8InputTextBuilder builder;
+    UTF8InputText text;
+    ProlongedSoundMarkTextPlugin plugin;
+    
+    @Before
+    public void setUp() {
+        builder = new UTF8InputTextBuilder(ORIGINAL_TEXT, new MockGrammar());
+        plugin = new ProlongedSoundMarkTextPlugin();
+        try {
+            plugin.setUp();
+        }
+        catch (IOException ex) {
+            ex.printStackTrace();
+        }
+    }
+    
+    @Test
+    public void beforeRewrite() {
+        assertThat(builder.getOriginalText(), is(ORIGINAL_TEXT));
+        assertThat(builder.getText(), is(ORIGINAL_TEXT));
+        text = builder.build();
+        assertThat(text.getOriginalText(), is(ORIGINAL_TEXT));
+        assertThat(text.getText(), is(ORIGINAL_TEXT));
+        byte[] bytes = text.getByteText();
+        assertThat(bytes.length, is(21));
+        assertArrayEquals(
+            new byte[] {
+                    (byte)0xE3, (byte)0x82, (byte)0xB4, (byte)0xE3,
+                    (byte)0x83, (byte)0xBC, (byte)0xE3, (byte)0x83,
+                    (byte)0xBC, (byte)0xE3, (byte)0x83, (byte)0xBC,
+                    (byte)0xE3, (byte)0x83, (byte)0xBC, (byte)0xE3,
+                    (byte)0x83, (byte)0xBC, (byte)0xE3, (byte)0x83,
+                    (byte)0xAB
+            }, bytes
+        );
+        assertThat(text.getOriginalIndex(0), is(0));
+        assertThat(text.getOriginalIndex(3), is(1));
+        assertThat(text.getOriginalIndex(6), is(2));
+        assertThat(text.getOriginalIndex(9), is(3));
+        assertThat(text.getOriginalIndex(12), is(4));
+        assertThat(text.getOriginalIndex(15), is(5));
+        assertThat(text.getOriginalIndex(18), is(6));
+        assertThat(text.getOriginalIndex(21), is(7));
+    }
+
+    @Test
+    public void afterRewrite() {
+        assertThat(builder.getOriginalText(), is(ORIGINAL_TEXT));
+        assertThat(builder.getText(), is(ORIGINAL_TEXT));
+        plugin.rewrite(builder);
+        text = builder.build();
+        assertThat(text.getOriginalText(), is(ORIGINAL_TEXT));
+        assertThat(text.getText(), is(NORMALIZED_TEXT));
+        byte[] bytes = text.getByteText();
+        assertThat(bytes.length, is(9));
+        assertArrayEquals(
+                new byte[] {
+                        (byte)0xE3, (byte)0x82, (byte)0xB4, (byte)0xE3,
+                        (byte)0x83, (byte)0xBC, (byte)0xE3, (byte)0x83,
+                        (byte)0xAB
+                }, bytes
+        );
+        assertThat(text.getOriginalIndex(0), is(0));
+        assertThat(text.getOriginalIndex(3), is(1));
+        assertThat(text.getOriginalIndex(6), is(6));
+        assertThat(text.getOriginalIndex(9), is(7));
+    }
+
+    class MockGrammar implements Grammar {
+        @Override
+        public int getPartOfSpeechSize() {
+            return 0;
+        }
+        @Override
+        public List<String> getPartOfSpeechString(short posId) {
+            return null;
+        }
+        @Override
+        public short getPartOfSpeechId(List<String> pos) {
+            return 0;
+        }
+        @Override
+        public short getConnectCost(short leftId, short rightId) {
+            return 0;
+        }
+        @Override
+        public void setConnectCost(short leftId, short rightId, short cost) {}
+        @Override
+        public short[] getBOSParameter() {
+            return null;
+        }
+        @Override
+        public short[] getEOSParameter() {
+            return null;
+        }
+        @Override
+        public CharacterCategory getCharacterCategory() {
+            CharacterCategory charCategory = new CharacterCategory();
+            try {
+                charCategory.readCharacterDefinition(DefaultInputTextPluginTest.class.getClassLoader()
+                    .getResource("char.def").getPath());
+            }
+            catch (IOException ex) {
+                ex.printStackTrace();
+            }
+            return charCategory;
+        }
+        @Override
+        public void setCharacterCategory(CharacterCategory charCategory) {
+        }
+    }
+}

--- a/src/test/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPluginTest.java
+++ b/src/test/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPluginTest.java
@@ -127,6 +127,36 @@ public class ProlongedSoundMarkInputTextPluginTest {
         assertThat(text.getOriginalIndex(18), is(12));
     }
 
+    @Test
+    public void combineContinuousProlongedSoundMarksMultipleSymbolTypes() {
+        final String ORIGINAL_TEXT = "エーービ〜〜〜シ〰〰〰〰";
+        final String NORMALIZED_TEXT = "エービーシー";
+        builder = new UTF8InputTextBuilder(ORIGINAL_TEXT, new MockGrammar());
+        plugin.rewrite(builder);
+        text = builder.build();
+
+        assertThat(text.getOriginalText(), is(ORIGINAL_TEXT));
+        assertThat(text.getText(), is(NORMALIZED_TEXT));
+        byte[] bytes = text.getByteText();
+        assertThat(bytes.length, is(18));
+        assertArrayEquals(
+                new byte[] {
+                        (byte)0xE3, (byte)0x82, (byte)0xA8, (byte)0xE3,
+                        (byte)0x83, (byte)0xBC, (byte)0xE3, (byte)0x83,
+                        (byte)0x93, (byte)0xE3, (byte)0x83, (byte)0xBC,
+                        (byte)0xE3, (byte)0x82, (byte)0xB7, (byte)0xE3,
+                        (byte)0x83, (byte)0xBC
+                }, bytes
+        );
+        assertThat(text.getOriginalIndex(0), is(0));
+        assertThat(text.getOriginalIndex(3), is(1));
+        assertThat(text.getOriginalIndex(6), is(3));
+        assertThat(text.getOriginalIndex(9), is(4));
+        assertThat(text.getOriginalIndex(12), is(7));
+        assertThat(text.getOriginalIndex(15), is(8));
+        assertThat(text.getOriginalIndex(18), is(12));
+    }
+
     class MockGrammar implements Grammar {
         @Override
         public int getPartOfSpeechSize() {

--- a/src/test/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPluginTest.java
+++ b/src/test/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPluginTest.java
@@ -170,6 +170,36 @@ public class ProlongedSoundMarkInputTextPluginTest {
         assertThat(text.getOriginalIndex(18), is(12));
     }
 
+    @Test
+    public void combineContinuousProlongedSoundMarksMultipleMixedSymbolTypes() {
+        final String ORIGINAL_TEXT = "エー〜ビ〜〰ーシ〰ー〰〜";
+        final String NORMALIZED_TEXT = "エービーシー";
+        builder = new UTF8InputTextBuilder(ORIGINAL_TEXT, new MockGrammar());
+        plugin.rewrite(builder);
+        text = builder.build();
+
+        assertThat(text.getOriginalText(), is(ORIGINAL_TEXT));
+        assertThat(text.getText(), is(NORMALIZED_TEXT));
+        byte[] bytes = text.getByteText();
+        assertThat(bytes.length, is(18));
+        assertArrayEquals(
+                new byte[] {
+                        (byte)0xE3, (byte)0x82, (byte)0xA8, (byte)0xE3,
+                        (byte)0x83, (byte)0xBC, (byte)0xE3, (byte)0x83,
+                        (byte)0x93, (byte)0xE3, (byte)0x83, (byte)0xBC,
+                        (byte)0xE3, (byte)0x82, (byte)0xB7, (byte)0xE3,
+                        (byte)0x83, (byte)0xBC
+                }, bytes
+        );
+        assertThat(text.getOriginalIndex(0), is(0));
+        assertThat(text.getOriginalIndex(3), is(1));
+        assertThat(text.getOriginalIndex(6), is(3));
+        assertThat(text.getOriginalIndex(9), is(4));
+        assertThat(text.getOriginalIndex(12), is(7));
+        assertThat(text.getOriginalIndex(15), is(8));
+        assertThat(text.getOriginalIndex(18), is(12));
+    }
+
     class MockGrammar implements Grammar {
         @Override
         public int getPartOfSpeechSize() {

--- a/src/test/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPluginTest.java
+++ b/src/test/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPluginTest.java
@@ -48,7 +48,7 @@ public class ProlongedSoundMarkInputTextPluginTest {
     
     @Test
     public void combineContinuousProlongedSoundMarks() {
-        final String ORIGINAL_TEXT = "ゴーーーーール";
+        final String ORIGINAL_TEXT = "ゴーール";
         final String NORMALIZED_TEXT = "ゴール";
         builder = new UTF8InputTextBuilder(ORIGINAL_TEXT, new MockGrammar());
         plugin.rewrite(builder);
@@ -67,13 +67,13 @@ public class ProlongedSoundMarkInputTextPluginTest {
         );
         assertThat(text.getOriginalIndex(0), is(0));
         assertThat(text.getOriginalIndex(3), is(1));
-        assertThat(text.getOriginalIndex(6), is(6));
-        assertThat(text.getOriginalIndex(9), is(7));
+        assertThat(text.getOriginalIndex(6), is(3));
+        assertThat(text.getOriginalIndex(9), is(4));
     }
 
     @Test
     public void combineContinuousProlongedSoundMarksAtEnd() {
-        final String ORIGINAL_TEXT = "スーパーーー";
+        final String ORIGINAL_TEXT = "スーパーー";
         final String NORMALIZED_TEXT = "スーパー";
         builder = new UTF8InputTextBuilder(ORIGINAL_TEXT, new MockGrammar());
         plugin.rewrite(builder);
@@ -94,7 +94,7 @@ public class ProlongedSoundMarkInputTextPluginTest {
         assertThat(text.getOriginalIndex(3), is(1));
         assertThat(text.getOriginalIndex(6), is(2));
         assertThat(text.getOriginalIndex(9), is(3));
-        assertThat(text.getOriginalIndex(12), is(6));
+        assertThat(text.getOriginalIndex(12), is(5));
     }
 
     @Test

--- a/src/test/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPluginTest.java
+++ b/src/test/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPluginTest.java
@@ -31,15 +31,12 @@ import com.worksap.nlp.sudachi.dictionary.Grammar;
 
 public class ProlongedSoundMarkInputTextPluginTest {
     
-    static final String ORIGINAL_TEXT = "ゴーーーーール";
-    static final String NORMALIZED_TEXT = "ゴール";
     UTF8InputTextBuilder builder;
     UTF8InputText text;
     ProlongedSoundMarkTextPlugin plugin;
     
     @Before
     public void setUp() {
-        builder = new UTF8InputTextBuilder(ORIGINAL_TEXT, new MockGrammar());
         plugin = new ProlongedSoundMarkTextPlugin();
         try {
             plugin.setUp();
@@ -50,40 +47,13 @@ public class ProlongedSoundMarkInputTextPluginTest {
     }
     
     @Test
-    public void beforeRewrite() {
-        assertThat(builder.getOriginalText(), is(ORIGINAL_TEXT));
-        assertThat(builder.getText(), is(ORIGINAL_TEXT));
-        text = builder.build();
-        assertThat(text.getOriginalText(), is(ORIGINAL_TEXT));
-        assertThat(text.getText(), is(ORIGINAL_TEXT));
-        byte[] bytes = text.getByteText();
-        assertThat(bytes.length, is(21));
-        assertArrayEquals(
-            new byte[] {
-                    (byte)0xE3, (byte)0x82, (byte)0xB4, (byte)0xE3,
-                    (byte)0x83, (byte)0xBC, (byte)0xE3, (byte)0x83,
-                    (byte)0xBC, (byte)0xE3, (byte)0x83, (byte)0xBC,
-                    (byte)0xE3, (byte)0x83, (byte)0xBC, (byte)0xE3,
-                    (byte)0x83, (byte)0xBC, (byte)0xE3, (byte)0x83,
-                    (byte)0xAB
-            }, bytes
-        );
-        assertThat(text.getOriginalIndex(0), is(0));
-        assertThat(text.getOriginalIndex(3), is(1));
-        assertThat(text.getOriginalIndex(6), is(2));
-        assertThat(text.getOriginalIndex(9), is(3));
-        assertThat(text.getOriginalIndex(12), is(4));
-        assertThat(text.getOriginalIndex(15), is(5));
-        assertThat(text.getOriginalIndex(18), is(6));
-        assertThat(text.getOriginalIndex(21), is(7));
-    }
-
-    @Test
-    public void afterRewrite() {
-        assertThat(builder.getOriginalText(), is(ORIGINAL_TEXT));
-        assertThat(builder.getText(), is(ORIGINAL_TEXT));
+    public void combineContinuousProlongedSoundMarks() {
+        final String ORIGINAL_TEXT = "ゴーーーーール";
+        final String NORMALIZED_TEXT = "ゴール";
+        builder = new UTF8InputTextBuilder(ORIGINAL_TEXT, new MockGrammar());
         plugin.rewrite(builder);
         text = builder.build();
+
         assertThat(text.getOriginalText(), is(ORIGINAL_TEXT));
         assertThat(text.getText(), is(NORMALIZED_TEXT));
         byte[] bytes = text.getByteText();

--- a/src/test/resources/sudachi.json
+++ b/src/test/resources/sudachi.json
@@ -2,6 +2,11 @@
     "systemDict" : "system.dic",
     "userDict" : [ "user.dic" ],
     "characterDefinitionFile" : "char.def",
+    "inputTextPlugin" : [
+        { "class" : "com.worksap.nlp.sudachi.ProlongedSoundMarkInputTextPlugin",
+          "prolongedSoundMarks": ["ー", "〜", "〰"],
+          "replacementSymbol": "ー"}
+    ],
     "oovProviderPlugin" : [
         { "class" : "com.worksap.nlp.sudachi.SimpleOovProviderPlugin",
           "oovPOS" : [ "名詞", "普通名詞", "一般", "*", "*", "*" ],


### PR DESCRIPTION
Add a plugin that rewrites the Katakana-Hiragana Prolonged Sound Mark (Chōonpu) and similar symbols.

This plugin shrinks the continuous sequence of prolonged sound marks to 1 character.

c.f. 
* [Chōonpu - Wikipedia](https://en.wikipedia.org/wiki/Ch%C5%8Donpu) (en)
* [長音符 - Wikipedia](https://ja.wikipedia.org/wiki/%E9%95%B7%E9%9F%B3%E7%AC%A6) (ja)
* [Regexp · neologd/mecab-ipadic-neologd Wiki](https://github.com/neologd/mecab-ipadic-neologd/wiki/Regexp) (NEologd's case, ja)