### PR TITLE
Fix JoinNumericPlugin not working with joinAllNumeric option

### DIFF
--- a/src/main/java/com/worksap/nlp/sudachi/JoinNumericPlugin.java
+++ b/src/main/java/com/worksap/nlp/sudachi/JoinNumericPlugin.java
@@ -89,7 +89,7 @@ class JoinNumericPlugin extends PathRewritePlugin {
                     }
                     i = beginIndex + 1;
                 }
-                if (joinKanjiNumeric) {
+                if (joinKanjiNumeric || joinAllNumeric) {
                     type = CategoryType.KANJINUMERIC;
                     beginIndex = i;
                 } else {

--- a/src/test/java/com/worksap/nlp/sudachi/JoinNumericPluginTest.java
+++ b/src/test/java/com/worksap/nlp/sudachi/JoinNumericPluginTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2017 Works Applications Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.worksap.nlp.sudachi;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.worksap.nlp.sudachi.dictionary.CategoryType;
+import org.junit.rules.TemporaryFolder;
+
+public class JoinNumericPluginTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    JapaneseTokenizer tokenizer;
+    JoinNumericPlugin plugin;
+
+    @Before
+    public void setUp() throws IOException {
+        Utils.copyResource(temporaryFolder.getRoot().toPath(),
+                "/system.dic", "/user.dic", "/joinnumeric/char.def", "/unk.def");
+
+        String path = temporaryFolder.getRoot().getPath();
+        String settings = Utils.readAllResource("/sudachi.json");
+        Dictionary dict = new DictionaryFactory().create(path, settings);
+        tokenizer = (JapaneseTokenizer)dict.create();
+
+        plugin = new JoinNumericPlugin();
+    }
+
+    @Test
+    public void testKanjiNumericEnabled() {
+        plugin.joinKanjiNumeric = true;
+
+        UTF8InputText input = getInputText("123一二三123");
+        List<LatticeNode> path = tokenize(input);
+        plugin.rewrite(input, path, tokenizer.lattice);
+
+        assertEquals(3, path.size());
+        assertEquals("123", path.get(0).getWordInfo().getSurface());
+        assertEquals("一二三", path.get(1).getWordInfo().getSurface());
+        assertEquals("123", path.get(2).getWordInfo().getSurface());
+    }
+
+    @Test
+    public void testAllNumericEnabledNumericKanjiNumeric() {
+        plugin.joinAllNumeric = true;
+
+        UTF8InputText input = getInputText("123一二三123");
+        List<LatticeNode> path = tokenize(input);
+        plugin.rewrite(input, path, tokenizer.lattice);
+
+        assertEquals(1, path.size());
+        assertEquals("123一二三123", path.get(0).getWordInfo().getSurface());
+    }
+
+    @Test
+    public void testAllNumericEnabledKanjiNumeric() {
+        plugin.joinAllNumeric = true;
+
+        UTF8InputText input = getInputText("一二三");
+        List<LatticeNode> path = tokenize(input);
+        plugin.rewrite(input, path, tokenizer.lattice);
+
+        assertEquals(1, path.size());
+        assertEquals("一二三", path.get(0).getWordInfo().getSurface());
+    }
+
+    @Test
+    public void testAllNumericEnabledNonNumericKanjiNumeric() {
+        plugin.joinAllNumeric = true;
+
+        UTF8InputText input = getInputText(".一二三");
+        List<LatticeNode> path = tokenize(input);
+        plugin.rewrite(input, path, tokenizer.lattice);
+
+        assertEquals(2, path.size());
+        assertEquals(".", path.get(0).getWordInfo().getSurface());
+        assertEquals("一二三", path.get(1).getWordInfo().getSurface());
+    }
+
+    private UTF8InputText getInputText(String text) {
+        UTF8InputTextBuilder builder = new UTF8InputTextBuilder(text, tokenizer.grammar);
+        return builder.build();
+    }
+
+    /* Copied from JapaneseTokenizer#tokenize() */
+    private List<LatticeNode> tokenize(UTF8InputText input) {
+        byte[] bytes = input.getByteText();
+        tokenizer.lattice.resize(bytes.length);
+
+        for (int i = 0; i < bytes.length; i++) {
+            if (!input.canBow(i) || !tokenizer.lattice.hasPreviousNode(i)) {
+                continue;
+            }
+            Iterator<int[]> iterator = tokenizer.lexicon.lookup(bytes, i);
+            boolean hasWords = iterator.hasNext();
+            while (iterator.hasNext()) {
+                int[] r = iterator.next();
+                int wordId = r[0];
+                int end = r[1];
+
+                LatticeNode n = new LatticeNodeImpl(tokenizer.lexicon,
+                        tokenizer.lexicon.getLeftId(wordId),
+                        tokenizer.lexicon.getRightId(wordId),
+                        tokenizer.lexicon.getCost(wordId),
+                        wordId);
+                tokenizer.lattice.insert(i, end, n);
+            }
+
+            // OOV
+            if (!input.getCharCategoryTypes(i).contains(CategoryType.NOOOVBOW)) {
+                for (OovProviderPlugin plugin : tokenizer.oovProviderPlugins) {
+                    for (LatticeNode node : plugin.getOOV(input, i, hasWords)) {
+                        hasWords = true;
+                        tokenizer.lattice.insert(node.getBegin(), node.getEnd(), node);
+                    }
+                }
+            }
+            if (!hasWords && tokenizer.defaultOovProvider != null) {
+                for (LatticeNode node : tokenizer.defaultOovProvider.getOOV(input, i, hasWords)) {
+                    hasWords = true;
+                    tokenizer.lattice.insert(node.getBegin(), node.getEnd(), node);
+                }
+            }
+            if (!hasWords) {
+                throw new IllegalStateException("there is no morpheme at " + i);
+            }
+        }
+
+        List<LatticeNode> path = tokenizer.lattice.getBestPath();
+        tokenizer.lattice.clear();
+
+        path.remove(path.size() - 1); // remove EOS
+        return path;
+    }
+
+}

--- a/src/test/resources/joinnumeric/char.def
+++ b/src/test/resources/joinnumeric/char.def
@@ -1,0 +1,164 @@
+#
+#   Japanese charcter category map
+#
+#   $Id: char.def 9 2012-12-12 04:13:15Z togiso $;
+#
+
+###################################################################################
+# 
+#  CHARACTER CATEGORY DEFINITION
+#
+#  CATEGORY_NAME INVOKE GROUP LENGTH
+#
+#   - CATEGORY_NAME: Name of category. you have to define DEFAULT class.
+#   - INVOKE: 1/0:   always invoke unknown word processing, evan when the word can be found in the lexicon
+#   - GROUP:  1/0:   make a new word by grouping the same chracter category
+#   - LENGTH: n:     1 to n length new words are added
+#
+DEFAULT         0 1 0  # DEFAULT is a mandatory category!
+SPACE           0 1 0  
+KANJI           0 0 2
+SYMBOL          1 1 0
+NUMERIC         1 1 0
+ALPHA           1 1 0
+HIRAGANA        0 1 2
+KATAKANA        1 1 2
+KANJINUMERIC    0 1 0  #change INVOKE 1->0
+GREEK           1 1 0
+CYRILLIC        1 1 0
+
+###################################################################################
+#
+# CODE(UCS2) TO CATEGORY MAPPING
+#
+
+# SPACE
+0x0020 SPACE  # DO NOT REMOVE THIS LINE, 0x0020 is reserved for SPACE
+0x000D SPACE
+0x0009 SPACE
+0x000B SPACE
+0x000A SPACE
+
+# ASCII
+0x0021..0x002F SYMBOL   #!"#$%&'()*+,-./
+0x0030..0x0039 NUMERIC  #0-9
+0x003A..0x0040 SYMBOL   #:;<=>?@
+0x0041..0x005A ALPHA    #A-Z
+0x005B..0x0060 SYMBOL   #[\]^_`
+0x0061..0x007A ALPHA    #a-z
+0x007B..0x007E SYMBOL   #{|}~
+
+# Latin
+0x00A1..0x00BF SYMBOL # Latin 1 #¡->¿
+0x00C0..0x00D6 ALPHA  # Latin 1 #À->Ö
+0x00D7         SYMBOL # Latin 1 #×
+0x00D8..0x00F6 ALPHA  # Latin 1 #Ø->ö
+0x00F7         SYMBOL # Latin 1 #÷
+0x00F8..0x00FF ALPHA  # Latin 1 #ø->ÿ
+0x0100..0x017F ALPHA  # Latin Extended A
+0x0180..0x0236 ALPHA  # Latin Extended B
+0x1E00..0x1EF9 ALPHA  # Latin Extended Additional
+
+# CYRILLIC
+0x0400..0x04F9 CYRILLIC #Ѐ->ӹ
+0x0500..0x050F CYRILLIC # Cyrillic supplementary
+
+# GREEK
+0x0374..0x03FB GREEK # Greek and Coptic　#ʹ->ϻ
+
+# HIRAGANA
+0x3041..0x309F  HIRAGANA
+
+# KATAKANA
+#0x30A1..0x30FF  KATAKANA
+0x30A1..0x30FA  KATAKANA
+0x30FC..0x30FF  KATAKANA
+0x31F0..0x31FF  KATAKANA  # Small KU .. Small RO
+# 0x30FC          KATAKANA HIRAGANA  # ー
+0x30A1          NOOOVBOW # Small A
+0x30A3          NOOOVBOW
+0x30A5          NOOOVBOW
+0x30A7          NOOOVBOW
+0x30A9          NOOOVBOW
+0x30E3          NOOOVBOW
+0x30E5          NOOOVBOW
+0x30E7          NOOOVBOW
+0x30EE          NOOOVBOW
+0x30FB..0x30FE  NOOOVBOW
+
+# Half KATAKANA
+0xFF66..0xFF9D  KATAKANA
+0xFF9E..0xFF9F  KATAKANA
+
+# KANJI
+0x2E80..0x2EF3  KANJI # CJK Raidcals Supplement
+0x2F00..0x2FD5  KANJI
+0x3005          KANJI NOOOVBOW
+0x3007          KANJI
+0x3400..0x4DB5  KANJI # CJK Unified Ideographs Extention
+#0x4E00..0x9FA5  KANJI
+0x4E00..0x9FFF  KANJI
+0xF900..0xFA2D  KANJI
+0xFA30..0xFA6A  KANJI
+
+
+# KANJI-NUMERIC (一 二 三 四 五 六 七 八 九 十 百 千 万 億 兆)
+0x4E00 KANJINUMERIC KANJI
+0x4E8C KANJINUMERIC KANJI
+0x4E09 KANJINUMERIC KANJI
+0x56DB KANJINUMERIC KANJI
+0x4E94 KANJINUMERIC KANJI
+0x516D KANJINUMERIC KANJI
+0x4E03 KANJINUMERIC KANJI
+0x516B KANJINUMERIC KANJI
+0x4E5D KANJINUMERIC KANJI
+0x5341 KANJINUMERIC KANJI
+0x767E KANJINUMERIC KANJI
+0x5343 KANJINUMERIC KANJI
+0x4E07 KANJINUMERIC KANJI
+0x5104 KANJINUMERIC KANJI
+0x5146 KANJINUMERIC KANJI
+
+# ZENKAKU 
+0xFF10..0xFF19 NUMERIC
+0xFF21..0xFF3A ALPHA
+0xFF41..0xFF5A ALPHA
+0xFF01..0xFF0F SYMBOL   #！->／
+0xFF1A..0xFF20 SYMBOL   #：->＠
+0xFF3B..0xFF40 SYMBOL   #［->｀
+0xFF5B..0xFF65 SYMBOL   #｛->･
+0xFFE0..0xFFEF SYMBOL # HalfWidth and Full width Form
+
+# OTHER SYMBOLS
+0x2000..0x206F  SYMBOL # General Punctuation
+0x2070..0x209F  NUMERIC # Superscripts and Subscripts
+0x20A0..0x20CF  SYMBOL # Currency Symbols
+0x20D0..0x20FF  SYMBOL # Combining Diaritical Marks for Symbols
+0x2100..0x214F  SYMBOL # Letterlike Symbols
+0x2150..0x218F  NUMERIC # Number forms
+0x2100..0x214B  SYMBOL # Letterlike Symbols
+0x2190..0x21FF  SYMBOL # Arrow
+0x2200..0x22FF  SYMBOL # Mathematical Operators
+0x2300..0x23FF  SYMBOL # Miscellaneuos Technical
+0x2460..0x24FF  SYMBOL # Enclosed NUMERICs
+0x2501..0x257F  SYMBOL # Box Drawing
+0x2580..0x259F  SYMBOL # Block Elements
+0x25A0..0x25FF  SYMBOL # Geometric Shapes
+0x2600..0x26FE  SYMBOL # Miscellaneous Symbols
+0x2700..0x27BF  SYMBOL # Dingbats
+0x27F0..0x27FF  SYMBOL # Supplemental Arrows A
+0x27C0..0x27EF  SYMBOL # Miscellaneous Mathematical Symbols-A
+0x2800..0x28FF  SYMBOL # Braille Patterns
+0x2900..0x297F  SYMBOL # Supplemental Arrows B
+0x2B00..0x2BFF  SYMBOL # Miscellaneous Symbols and Arrows
+0x2A00..0x2AFF  SYMBOL # Supplemental Mathematical Operators
+0x3300..0x33FF  SYMBOL
+0x3200..0x32FE  SYMBOL # ENclosed CJK Letters and Months
+0x3000..0x303F  SYMBOL # CJK Symbol and Punctuation
+0xFE30..0xFE4F  SYMBOL # CJK Compatibility Forms
+0xFE50..0xFE6B  SYMBOL # Small Form Variants
+
+# added 2006/3/13 
+0x3007 SYMBOL KANJINUMERIC
+
+# END OF TABLE


### PR DESCRIPTION
Fix a bug on `JoinNumericPlugin`, when `joinAllNumeric` is enabled but `joinKanjiNumeric` is disabled, KanjiNumeric tokens are not concatenated.

This fixes the failures on the following methods in added test class.

- testAllNumericEnabledKanjiNumeric
- testAllNumericEnabledNonNumericKanjiNumeric