### PR TITLE
Change behaviors for voiced/semi-voiced sound marks

### DIFF
--- a/src/main/resources/char.def
+++ b/src/main/resources/char.def
@@ -161,4 +161,7 @@ CYRILLIC        1 1 0
 # added 2006/3/13 
 0x3007 SYMBOL KANJINUMERIC
 
+# added 2018/11/30
+0x309b..0x309c HIRAGANA KATAKANA # voiced/semi-voiced sound marks
+
 # END OF TABLE

--- a/src/main/resources/rewrite.def
+++ b/src/main/resources/rewrite.def
@@ -833,6 +833,8 @@
 𧻓
 齃
 龎
+゛
+゜
 
 # replace char list
 #   ^{before}\s{after}%n


### PR DESCRIPTION
Related to #48 

Change behaviors for `゛` (U+309B) and `゜` (U+309C) as follows
- Skip NFKC normalization in `InputTextPlugin`
- Change charactor categories into HIRAGANA and KATAKANA (not only HIRAGANA)

But this PR is incomplete to resolve this issue because the entry word for Trie tree in the lexicon also should be fixed to lookup these charactors as known morpheme. 