### PR TITLE
Fix a bug causing ByteBuffer throws NoSuchMethodError

### DIFF
--- a/src/main/java/com/worksap/nlp/sudachi/dictionary/DoubleArrayLexicon.java
+++ b/src/main/java/com/worksap/nlp/sudachi/dictionary/DoubleArrayLexicon.java
@@ -38,7 +38,7 @@ public class DoubleArrayLexicon implements Lexicon {
         trie = new DoubleArray();
         int size = bytes.getInt(offset);
         offset += 4;
-        ((Buffer) bytes).position(offset);
+        ((Buffer) bytes).position(offset); // a kludge for Java 9
         IntBuffer array = bytes.asIntBuffer();
         trie.setArray(array, size);
         offset += trie.totalSize();

--- a/src/main/java/com/worksap/nlp/sudachi/dictionary/GrammarImpl.java
+++ b/src/main/java/com/worksap/nlp/sudachi/dictionary/GrammarImpl.java
@@ -131,8 +131,9 @@ public class GrammarImpl implements Grammar {
         ByteBuffer newBuffer = ByteBuffer.allocate(2 * leftIdSize * rightIdSize);
         newBuffer.order(ByteOrder.LITTLE_ENDIAN);
         ByteBuffer srcBuffer = connectTableBytes.duplicate();
-        ((Buffer) srcBuffer).position(connectTableOffset);
-        srcBuffer.limit(connectTableOffset + 2 * leftIdSize * rightIdSize);
+        Buffer buffer = srcBuffer; // a kludge for Java 9
+        buffer.position(connectTableOffset);
+        buffer.limit(connectTableOffset + 2 * leftIdSize * rightIdSize);
         newBuffer.put(srcBuffer);
         connectTableBytes = newBuffer;
         connectTableOffset = 0;

--- a/src/main/java/com/worksap/nlp/sudachi/dictionary/WordInfoList.java
+++ b/src/main/java/com/worksap/nlp/sudachi/dictionary/WordInfoList.java
@@ -34,7 +34,7 @@ class WordInfoList {
     WordInfo getWordInfo(int wordId) {
         ByteBuffer buf = bytes.asReadOnlyBuffer();
         buf.order(bytes.order());
-        ((Buffer) buf).position(wordIdToOffset(wordId));
+        ((Buffer) buf).position(wordIdToOffset(wordId)); // a kludge for Java 9
 
         String surface = bufferToString(buf);
         short headwordLength = (short) bufferToStringLength(buf);

--- a/src/main/java/com/worksap/nlp/sudachi/dictionary/WordParameterList.java
+++ b/src/main/java/com/worksap/nlp/sudachi/dictionary/WordParameterList.java
@@ -71,8 +71,9 @@ class WordParameterList {
         ByteBuffer newBuffer = ByteBuffer.allocate(ELEMENT_SIZE * size);
         newBuffer.order(ByteOrder.LITTLE_ENDIAN);
         ByteBuffer srcBuffer = bytes.duplicate();
-        ((Buffer) srcBuffer).position(offset);
-        srcBuffer.limit(offset + ELEMENT_SIZE * size);
+        Buffer buffer = srcBuffer; // a kludge for Java 9
+        buffer.position(offset);
+        buffer.limit(offset + ELEMENT_SIZE * size);
         newBuffer.put(srcBuffer);
         bytes = newBuffer;
         offset = 0;

--- a/src/test/java/com/worksap/nlp/sudachi/dictionary/DictionaryBuilderTest.java
+++ b/src/test/java/com/worksap/nlp/sudachi/dictionary/DictionaryBuilderTest.java
@@ -163,7 +163,7 @@ public class DictionaryBuilderTest {
     public void convertPOSTable() {
         DictionaryBuilder builder = new DictionaryBuilder();
         builder.convertPOSTable(Arrays.asList("a,b,c,d,e,f", "g,h,i,j,k,l"));
-        assertThat(builder.buffer.position(), is(2 + 3 * 12));
+        assertThat(builder.byteBuffer.position(), is(2 + 3 * 12));
     }
 
     @Test
@@ -172,8 +172,8 @@ public class DictionaryBuilderTest {
                 "2 3\n0 0 0\n0 1 1\n0 2 2\n\n1 0 3\n1 1 4\n1 2 5\n".getBytes(StandardCharsets.UTF_8));
         DictionaryBuilder builder = new DictionaryBuilder();
         ByteBuffer matrix = builder.convertMatrix(input);
-        assertThat(builder.buffer.getShort(0), is((short) 2));
-        assertThat(builder.buffer.getShort(2), is((short) 3));
+        assertThat(builder.byteBuffer.getShort(0), is((short) 2));
+        assertThat(builder.byteBuffer.getShort(2), is((short) 3));
         assertThat(matrix.limit(), is(2 * 3 * 2));
         assertThat(matrix.getShort(0), is((short) 0));
         assertThat(matrix.getShort((2 + 1) * 2), is((short) 4));
@@ -222,40 +222,40 @@ public class DictionaryBuilderTest {
     @Test
     public void writeString() {
         DictionaryBuilder builder = new DictionaryBuilder();
-        int position = builder.buffer.position();
+        int position = builder.byteBuffer.position();
         builder.writeString("");
-        assertThat(builder.buffer.get(position), is((byte) 0));
-        assertThat(builder.buffer.position(), is(position + 1));
+        assertThat(builder.byteBuffer.get(position), is((byte) 0));
+        assertThat(builder.byteBuffer.position(), is(position + 1));
 
-        position = builder.buffer.position();
+        position = builder.byteBuffer.position();
         builder.writeString("あ𠮟");
-        assertThat(builder.buffer.get(position), is((byte) 3));
-        assertThat(builder.buffer.getChar(position + 1), is('あ'));
-        assertThat(builder.buffer.getChar(position + 3), is('\ud842'));
-        assertThat(builder.buffer.getChar(position + 5), is('\udf9f'));
-        assertThat(builder.buffer.position(), is(position + 7));
+        assertThat(builder.byteBuffer.get(position), is((byte) 3));
+        assertThat(builder.byteBuffer.getChar(position + 1), is('あ'));
+        assertThat(builder.byteBuffer.getChar(position + 3), is('\ud842'));
+        assertThat(builder.byteBuffer.getChar(position + 5), is('\udf9f'));
+        assertThat(builder.byteBuffer.position(), is(position + 7));
 
-        position = builder.buffer.position();
+        position = builder.byteBuffer.position();
         final String longString = "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789";
         int length = longString.length();
         builder.writeString(longString);
-        assertThat(builder.buffer.get(position), is((byte) (length >> 8 | 0x80)));
-        assertThat(builder.buffer.get(position + 1), is((byte) (length & 0xff)));
-        assertThat(builder.buffer.position(), is(position + 2 + length * 2));
+        assertThat(builder.byteBuffer.get(position), is((byte) (length >> 8 | 0x80)));
+        assertThat(builder.byteBuffer.get(position + 1), is((byte) (length & 0xff)));
+        assertThat(builder.byteBuffer.position(), is(position + 2 + length * 2));
     }
 
     @Test
     public void writeIntArray() {
         DictionaryBuilder builder = new DictionaryBuilder();
-        int position = builder.buffer.position();
+        int position = builder.byteBuffer.position();
         builder.writeIntArray(new int[] {});
-        assertThat(builder.buffer.get(position), is((byte) 0));
+        assertThat(builder.byteBuffer.get(position), is((byte) 0));
         builder.writeIntArray(new int[] { 1, 2, 3 });
-        assertThat(builder.buffer.get(position + 1), is((byte) 3));
-        assertThat(builder.buffer.getInt(position + 2), is(1));
-        assertThat(builder.buffer.getInt(position + 6), is(2));
-        assertThat(builder.buffer.getInt(position + 10), is(3));
-        assertThat(builder.buffer.position(), is(position + 14));
+        assertThat(builder.byteBuffer.get(position + 1), is((byte) 3));
+        assertThat(builder.byteBuffer.getInt(position + 2), is(1));
+        assertThat(builder.byteBuffer.getInt(position + 6), is(2));
+        assertThat(builder.byteBuffer.getInt(position + 10), is(3));
+        assertThat(builder.byteBuffer.position(), is(position + 14));
     }
 
     @Test


### PR DESCRIPTION
In Java 9, the following methods of java.nio.ByteBuffer return
ByteBuffer instead of Buffer:
* position
* limit
* flip
* clear
This change breaks the compatibility of the byte code.