### PR TITLE
Feature/ignore yomigana

### DIFF
--- a/src/main/java/com/worksap/nlp/sudachi/DefaultInputTextPlugin.java
+++ b/src/main/java/com/worksap/nlp/sudachi/DefaultInputTextPlugin.java
@@ -29,6 +29,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import com.worksap.nlp.sudachi.dictionary.Grammar;
+
 /**
  * A plugin that rewrites the characters of input texts.
  *
@@ -43,7 +45,7 @@ import java.util.Set;
  *
  * <p>
  * The following is an example of settings.
- * 
+ *
  * <pre>
  * {@code
  *   {
@@ -58,7 +60,7 @@ import java.util.Set;
  *
  * <p>
  * The following is an example of rewriting rules.
- * 
+ *
  * <pre>
  * {@code
  * # single code point: this character is skipped in character normalization
@@ -84,7 +86,7 @@ class DefaultInputTextPlugin extends InputTextPlugin {
      *             if the file is not available.
      */
     @Override
-    public void setUp() throws IOException {
+    public void setUp(Grammar grammar) throws IOException {
         if (rewriteDef == null) {
             rewriteDef = settings.getPath("rewriteDef");
         }

--- a/src/main/java/com/worksap/nlp/sudachi/IgnoreYomiganaPlugin.java
+++ b/src/main/java/com/worksap/nlp/sudachi/IgnoreYomiganaPlugin.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2020 Works Applications Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.worksap.nlp.sudachi;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.worksap.nlp.sudachi.dictionary.CategoryType;
+import com.worksap.nlp.sudachi.dictionary.Grammar;
+
+/**
+ * A plugin that ignores the Yomigana written in brackets after the Kanji.
+ *
+ * <p>
+ * {@link Dictionary} initialize this plugin with {@link Settings}. It can be
+ * referred as {@link Plugin#settings}.
+ *
+ * <p>
+ * The following is an example of settings.
+ *
+ * <pre>
+ * {@code
+ *   {
+ *     "class" : "com.worksap.nlp.sudachi.IgnoreYomiganaPlugin",
+ *       "leftBrackets": ["(", "（"],
+ *       "rightBrackets": [")", "）"]
+ *   }
+ * }
+ * </pre>
+ *
+ * {@code leftBrackets} is the list of symbols to be used as left bracket.
+ * {@code rightBrackets} is the list of symbols to be used as right bracket.
+ *
+ * <p>
+ * With above setting example, the plugin rewrites input "徳島（とくしま）に行(い)く" to
+ * "徳島に行く".
+ */
+class IgnoreYomiganaPlugin extends InputTextPlugin {
+
+    private Set<Integer> leftBracketSet = new HashSet<>();
+    private Set<Integer> rightBracketSet = new HashSet<>();
+    private Grammar grammar;
+
+    @Override
+    public void setUp(Grammar grammar) throws IOException {
+        this.grammar = grammar;
+        List<String> leftBracketString = settings.getStringList("leftBrackets");
+        for (String s : leftBracketString) {
+            leftBracketSet.add(s.codePointAt(0));
+        }
+        List<String> rightBracketString = settings.getStringList("rightBrackets");
+        for (String s : rightBracketString) {
+            rightBracketSet.add(s.codePointAt(0));
+        }
+    }
+
+    @Override
+    public void rewrite(InputTextBuilder builder) {
+        String text = builder.getText();
+
+        int n = text.length();
+        int startBracketPoint = -1;
+        int offset = 0;
+        boolean hasYomigana = false;
+        for (int i = 1; i < n; i++) {
+            int cp = text.codePointAt(i);
+
+            if (isKanji(text.codePointAt(i - 1)) && leftBracketSet.contains(cp)) {
+                startBracketPoint = i;
+            } else if (hasYomigana && rightBracketSet.contains(cp)) {
+                builder.replace(startBracketPoint - 1 - offset, i + 1 - offset,
+                        text.substring(startBracketPoint - 1, startBracketPoint));
+                offset += i - startBracketPoint + 1;
+                startBracketPoint = -1;
+                hasYomigana = false;
+            } else if (startBracketPoint != -1) {
+                if (isHiragana(cp) || isKatakana(cp)) {
+                    hasYomigana = true;
+                } else {
+                    startBracketPoint = -1;
+                    hasYomigana = false;
+                }
+            }
+        }
+    }
+
+    private Boolean isKanji(int cp) {
+        return grammar.getCharacterCategory().getCategoryTypes(cp).contains(CategoryType.KANJI);
+    }
+
+    private Boolean isHiragana(int cp) {
+        return grammar.getCharacterCategory().getCategoryTypes(cp).contains(CategoryType.HIRAGANA);
+    }
+
+    private Boolean isKatakana(int cp) {
+        return grammar.getCharacterCategory().getCategoryTypes(cp).contains(CategoryType.KATAKANA);
+    }
+
+}

--- a/src/main/java/com/worksap/nlp/sudachi/IgnoreYomiganaPlugin.java
+++ b/src/main/java/com/worksap/nlp/sudachi/IgnoreYomiganaPlugin.java
@@ -39,7 +39,8 @@ import com.worksap.nlp.sudachi.dictionary.Grammar;
  *   {
  *     "class" : "com.worksap.nlp.sudachi.IgnoreYomiganaPlugin",
  *       "leftBrackets": ["(", "（"],
- *       "rightBrackets": [")", "）"]
+ *       "rightBrackets": [")", "）"],
+ *       "maxYomiganaLength": 4
  *   }
  * }
  * </pre>
@@ -55,6 +56,7 @@ class IgnoreYomiganaPlugin extends InputTextPlugin {
 
     private Set<Integer> leftBracketSet = new HashSet<>();
     private Set<Integer> rightBracketSet = new HashSet<>();
+    private int maxYomiganaLength;
     private Grammar grammar;
 
     @Override
@@ -68,6 +70,7 @@ class IgnoreYomiganaPlugin extends InputTextPlugin {
         for (String s : rightBracketString) {
             rightBracketSet.add(s.codePointAt(0));
         }
+        maxYomiganaLength = settings.getInt("maxYomiganaLength");
     }
 
     @Override
@@ -90,7 +93,7 @@ class IgnoreYomiganaPlugin extends InputTextPlugin {
                 startBracketPoint = -1;
                 hasYomigana = false;
             } else if (startBracketPoint != -1) {
-                if (isHiragana(cp) || isKatakana(cp)) {
+                if ((isHiragana(cp) || isKatakana(cp)) && i - startBracketPoint <= maxYomiganaLength) {
                     hasYomigana = true;
                 } else {
                     startBracketPoint = -1;

--- a/src/main/java/com/worksap/nlp/sudachi/IgnoreYomiganaPlugin.java
+++ b/src/main/java/com/worksap/nlp/sudachi/IgnoreYomiganaPlugin.java
@@ -70,7 +70,7 @@ class IgnoreYomiganaPlugin extends InputTextPlugin {
         for (String s : rightBracketString) {
             rightBracketSet.add(s.codePointAt(0));
         }
-        maxYomiganaLength = settings.getInt("maxYomiganaLength");
+        maxYomiganaLength = settings.getInt("maxYomiganaLength", 4);
     }
 
     @Override

--- a/src/main/java/com/worksap/nlp/sudachi/InputTextPlugin.java
+++ b/src/main/java/com/worksap/nlp/sudachi/InputTextPlugin.java
@@ -17,6 +17,7 @@
 package com.worksap.nlp.sudachi;
 
 import java.io.IOException;
+import com.worksap.nlp.sudachi.dictionary.Grammar;
 
 /**
  * A plugin that rewrites the characters of input texts.
@@ -27,7 +28,7 @@ import java.io.IOException;
  *
  * <p>
  * The following is an example of settings.
- * 
+ *
  * <pre>
  * {@code
  *   {
@@ -44,10 +45,12 @@ public abstract class InputTextPlugin extends Plugin {
      *
      * {@link Tokenizer} calls this method for setting up this plugin.
      *
+     * @param grammar
+     *            the grammar of the system dictionary
      * @throws IOException
      *             if reading something is failed
      */
-    public void setUp() throws IOException {
+    public void setUp(Grammar grammar) throws IOException {
     }
 
     /**

--- a/src/main/java/com/worksap/nlp/sudachi/JapaneseDictionary.java
+++ b/src/main/java/com/worksap/nlp/sudachi/JapaneseDictionary.java
@@ -65,7 +65,7 @@ class JapaneseDictionary implements Dictionary {
 
         inputTextPlugins = settings.getPluginList("inputTextPlugin");
         for (InputTextPlugin p : inputTextPlugins) {
-            p.setUp();
+            p.setUp(grammar);
         }
         oovProviderPlugins = settings.getPluginList("oovProviderPlugin");
         if (oovProviderPlugins.isEmpty()) {

--- a/src/main/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPlugin.java
+++ b/src/main/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPlugin.java
@@ -21,6 +21,8 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.List;
 
+import com.worksap.nlp.sudachi.dictionary.Grammar;
+
 /**
  * A plugin that rewrites the Katakana-Hiragana Prolonged Sound Mark (Chōonpu)
  * and similar symbols.
@@ -35,7 +37,7 @@ import java.util.List;
  *
  * <p>
  * The following is an example of settings.
- * 
+ *
  * <pre>
  * {@code
  *   {
@@ -60,7 +62,7 @@ class ProlongedSoundMarkInputTextPlugin extends InputTextPlugin {
     private String replacementSymbol;
 
     @Override
-    public void setUp() throws IOException {
+    public void setUp(Grammar Grammar) throws IOException {
         List<String> prolongedSoundMarkStrings = settings.getStringList("prolongedSoundMarks");
         for (String s : prolongedSoundMarkStrings) {
             prolongedSoundMarkSet.add(s.codePointAt(0));

--- a/src/main/resources/sudachi.json
+++ b/src/main/resources/sudachi.json
@@ -4,7 +4,10 @@
         { "class" : "com.worksap.nlp.sudachi.DefaultInputTextPlugin" },
         { "class" : "com.worksap.nlp.sudachi.ProlongedSoundMarkInputTextPlugin",
           "prolongedSoundMarks": ["ー", "-", "⁓", "〜", "〰"],
-          "replacementSymbol": "ー"}
+          "replacementSymbol": "ー"},
+	{ "class": "com.worksap.nlp.sudachi.IgnoreYomiganaPlugin",
+          "leftBrackets": ["(", "（"],
+          "rightBrackets": [")", "）"]}
     ],
     "oovProviderPlugin" : [
         { "class" : "com.worksap.nlp.sudachi.MeCabOovProviderPlugin" },

--- a/src/main/resources/sudachi.json
+++ b/src/main/resources/sudachi.json
@@ -5,9 +5,10 @@
         { "class" : "com.worksap.nlp.sudachi.ProlongedSoundMarkInputTextPlugin",
           "prolongedSoundMarks": ["ー", "-", "⁓", "〜", "〰"],
           "replacementSymbol": "ー"},
-	{ "class": "com.worksap.nlp.sudachi.IgnoreYomiganaPlugin",
+	      { "class": "com.worksap.nlp.sudachi.IgnoreYomiganaPlugin",
           "leftBrackets": ["(", "（"],
-          "rightBrackets": [")", "）"]}
+          "rightBrackets": [")", "）"],
+          "maxYomiganaLength": 4}
     ],
     "oovProviderPlugin" : [
         { "class" : "com.worksap.nlp.sudachi.MeCabOovProviderPlugin" },

--- a/src/test/java/com/worksap/nlp/sudachi/DefaultInputTextPluginTest.java
+++ b/src/test/java/com/worksap/nlp/sudachi/DefaultInputTextPluginTest.java
@@ -44,7 +44,7 @@ public class DefaultInputTextPluginTest {
         plugin = new DefaultInputTextPlugin();
         try {
             plugin.rewriteDef = DefaultInputTextPluginTest.class.getClassLoader().getResource("rewrite.def").getPath();
-            plugin.setUp();
+            plugin.setUp(new MockGrammar());
         } catch (IOException ex) {
             ex.printStackTrace();
         }
@@ -103,7 +103,7 @@ public class DefaultInputTextPluginTest {
     public void setUpWithNull() throws IOException {
         plugin = new DefaultInputTextPlugin();
         plugin.setSettings(new Settings(Json.createObjectBuilder().build(), null));
-        plugin.setUp();
+        plugin.setUp(new MockGrammar());
         assertThat(plugin.rewriteDef, is(nullValue()));
     }
 
@@ -112,7 +112,7 @@ public class DefaultInputTextPluginTest {
         plugin = new DefaultInputTextPlugin();
         plugin.rewriteDef = DefaultInputTextPluginTest.class.getClassLoader()
                 .getResource("rewrite_error_ignorelist.def").getPath();
-        plugin.setUp();
+        plugin.setUp(new MockGrammar());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -120,7 +120,7 @@ public class DefaultInputTextPluginTest {
         plugin = new DefaultInputTextPlugin();
         plugin.rewriteDef = DefaultInputTextPluginTest.class.getClassLoader()
                 .getResource("rewrite_error_replacelist.def").getPath();
-        plugin.setUp();
+        plugin.setUp(new MockGrammar());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -128,6 +128,6 @@ public class DefaultInputTextPluginTest {
         plugin = new DefaultInputTextPlugin();
         plugin.rewriteDef = DefaultInputTextPluginTest.class.getClassLoader().getResource("rewrite_error_dup.def")
                 .getPath();
-        plugin.setUp();
+        plugin.setUp(new MockGrammar());
     }
 }

--- a/src/test/java/com/worksap/nlp/sudachi/IgnoreYomiganaPluginTest.java
+++ b/src/test/java/com/worksap/nlp/sudachi/IgnoreYomiganaPluginTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2020 Works Applications Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.worksap.nlp.sudachi;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertArrayEquals;
+
+import java.io.IOException;
+import java.util.List;
+
+import javax.json.JsonObject;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.worksap.nlp.sudachi.dictionary.CharacterCategory;
+import com.worksap.nlp.sudachi.dictionary.Grammar;
+
+public class IgnoreYomiganaPluginTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    UTF8InputTextBuilder builder;
+    UTF8InputText text;
+    IgnoreYomiganaPlugin plugin;
+
+    @Before
+    public void setUp() throws IOException {
+        Utils.copyResource(temporaryFolder.getRoot().toPath(), "/system.dic", "/user.dic", "/char.def", "/unk.def");
+        String path = temporaryFolder.getRoot().getPath();
+        String jsonString = Utils.readAllResource("/sudachi.json");
+        Dictionary dict = new DictionaryFactory().create(path, jsonString);
+        plugin = new IgnoreYomiganaPlugin();
+
+        Settings settings = Settings.parseSettings(null, jsonString);
+        List<JsonObject> list = settings.getList("inputTextPlugin", JsonObject.class);
+        for (JsonObject p : list) {
+            if (p.getString("class").equals("com.worksap.nlp.sudachi.IgnoreYomiganaPlugin")) {
+                plugin.setSettings(new Settings(p, null));
+                break;
+            }
+        }
+
+        try {
+            plugin.setUp(((JapaneseDictionary) dict).grammar);
+        } catch (IOException ex) {
+            ex.printStackTrace();
+        }
+    }
+
+    @Test
+    public void ignoreYomiganaAtMiddle() {
+        final String ORIGINAL_TEXT = "徳島（とくしま）に行く";
+        final String NORMALIZED_TEXT = "徳島に行く";
+        builder = new UTF8InputTextBuilder(ORIGINAL_TEXT, new MockGrammar());
+        plugin.rewrite(builder);
+        text = builder.build();
+
+        assertThat(text.getOriginalText(), is(ORIGINAL_TEXT));
+        assertThat(text.getText(), is(NORMALIZED_TEXT));
+        byte[] bytes = text.getByteText();
+        assertThat(bytes.length, is(15));
+        assertArrayEquals(new byte[] { (byte) 0xE5, (byte) 0xBE, (byte) 0xB3, (byte) 0xE5, (byte) 0xB3, (byte) 0xB6,
+                (byte) 0xE3, (byte) 0x81, (byte) 0xAB, (byte) 0xE8, (byte) 0xA1, (byte) 0x8C, (byte) 0xE3, (byte) 0x81,
+                (byte) 0x8F }, bytes);
+        assertThat(text.getOriginalIndex(0), is(0));
+        assertThat(text.getOriginalIndex(3), is(1));
+        assertThat(text.getOriginalIndex(6), is(8));
+        assertThat(text.getOriginalIndex(9), is(9));
+        assertThat(text.getOriginalIndex(12), is(10));
+    }
+
+    @Test
+    public void ignoreYomiganaAtMiddleAtEnd() {
+        final String ORIGINAL_TEXT = "徳島（とくしま）";
+        final String NORMALIZED_TEXT = "徳島";
+        builder = new UTF8InputTextBuilder(ORIGINAL_TEXT, new MockGrammar());
+        plugin.rewrite(builder);
+        text = builder.build();
+
+        assertThat(text.getOriginalText(), is(ORIGINAL_TEXT));
+        assertThat(text.getText(), is(NORMALIZED_TEXT));
+        byte[] bytes = text.getByteText();
+        assertThat(bytes.length, is(6));
+        assertArrayEquals(new byte[] { (byte) 0xE5, (byte) 0xBE, (byte) 0xB3, (byte) 0xE5, (byte) 0xB3, (byte) 0xB6 },
+                bytes);
+        assertThat(text.getOriginalIndex(0), is(0));
+        assertThat(text.getOriginalIndex(3), is(1));
+    }
+
+    @Test
+    public void ignoreYomiganaMultipleTimes() {
+        final String ORIGINAL_TEXT = "徳島（とくしま）に行（い）く";
+        final String NORMALIZED_TEXT = "徳島に行く";
+        builder = new UTF8InputTextBuilder(ORIGINAL_TEXT, new MockGrammar());
+        plugin.rewrite(builder);
+        text = builder.build();
+
+        assertThat(text.getOriginalText(), is(ORIGINAL_TEXT));
+        assertThat(text.getText(), is(NORMALIZED_TEXT));
+        byte[] bytes = text.getByteText();
+        assertThat(bytes.length, is(15));
+        assertArrayEquals(new byte[] { (byte) 0xE5, (byte) 0xBE, (byte) 0xB3, (byte) 0xE5, (byte) 0xB3, (byte) 0xB6,
+                (byte) 0xE3, (byte) 0x81, (byte) 0xAB, (byte) 0xE8, (byte) 0xA1, (byte) 0x8C, (byte) 0xE3, (byte) 0x81,
+                (byte) 0x8F }, bytes);
+        assertThat(text.getOriginalIndex(0), is(0));
+        assertThat(text.getOriginalIndex(3), is(1));
+        assertThat(text.getOriginalIndex(6), is(8));
+        assertThat(text.getOriginalIndex(9), is(9));
+        assertThat(text.getOriginalIndex(12), is(13));
+    }
+
+    @Test
+    public void ignoreYomiganaMultipleBracketTypes() {
+        final String ORIGINAL_TEXT = "徳島(とくしま)に行（い）く";
+        final String NORMALIZED_TEXT = "徳島に行く";
+        builder = new UTF8InputTextBuilder(ORIGINAL_TEXT, new MockGrammar());
+        plugin.rewrite(builder);
+        text = builder.build();
+
+        assertThat(text.getOriginalText(), is(ORIGINAL_TEXT));
+        assertThat(text.getText(), is(NORMALIZED_TEXT));
+        byte[] bytes = text.getByteText();
+        assertThat(bytes.length, is(15));
+        assertArrayEquals(new byte[] { (byte) 0xE5, (byte) 0xBE, (byte) 0xB3, (byte) 0xE5, (byte) 0xB3, (byte) 0xB6,
+                (byte) 0xE3, (byte) 0x81, (byte) 0xAB, (byte) 0xE8, (byte) 0xA1, (byte) 0x8C, (byte) 0xE3, (byte) 0x81,
+                (byte) 0x8F }, bytes);
+        assertThat(text.getOriginalIndex(0), is(0));
+        assertThat(text.getOriginalIndex(3), is(1));
+        assertThat(text.getOriginalIndex(6), is(8));
+        assertThat(text.getOriginalIndex(9), is(9));
+        assertThat(text.getOriginalIndex(12), is(13));
+    }
+
+    @Test
+    public void doNotIgnoreIfNotYomigana() {
+        final String ORIGINAL_TEXT = "徳島に（よく）行く";
+        final String NORMALIZED_TEXT = "徳島に（よく）行く";
+        builder = new UTF8InputTextBuilder(ORIGINAL_TEXT, new MockGrammar());
+        plugin.rewrite(builder);
+        text = builder.build();
+
+        assertThat(text.getOriginalText(), is(ORIGINAL_TEXT));
+        assertThat(text.getText(), is(NORMALIZED_TEXT));
+        byte[] bytes = text.getByteText();
+        assertThat(bytes.length, is(27));
+        assertArrayEquals(new byte[] { (byte) 0xE5, (byte) 0xBE, (byte) 0xB3, (byte) 0xE5, (byte) 0xB3, (byte) 0xB6,
+                (byte) 0xE3, (byte) 0x81, (byte) 0xAB, (byte) 0xEF, (byte) 0xBC, (byte) 0x88, (byte) 0xE3, (byte) 0x82,
+                (byte) 0x88, (byte) 0xE3, (byte) 0x81, (byte) 0x8F, (byte) 0xEF, (byte) 0xBC, (byte) 0x89, (byte) 0xE8,
+                (byte) 0xA1, (byte) 0x8C, (byte) 0xE3, (byte) 0x81, (byte) 0x8F }, bytes);
+        assertThat(text.getOriginalIndex(0), is(0));
+        assertThat(text.getOriginalIndex(3), is(1));
+        assertThat(text.getOriginalIndex(6), is(2));
+        assertThat(text.getOriginalIndex(9), is(3));
+        assertThat(text.getOriginalIndex(12), is(4));
+        assertThat(text.getOriginalIndex(15), is(5));
+        assertThat(text.getOriginalIndex(18), is(6));
+        assertThat(text.getOriginalIndex(21), is(7));
+        assertThat(text.getOriginalIndex(24), is(8));
+    }
+
+    class MockGrammar implements Grammar {
+        @Override
+        public int getPartOfSpeechSize() {
+            return 0;
+        }
+
+        @Override
+        public List<String> getPartOfSpeechString(short posId) {
+            return null;
+        }
+
+        @Override
+        public short getPartOfSpeechId(List<String> pos) {
+            return 0;
+        }
+
+        @Override
+        public short getConnectCost(short leftId, short rightId) {
+            return 0;
+        }
+
+        @Override
+        public void setConnectCost(short leftId, short rightId, short cost) {
+        }
+
+        @Override
+        public short[] getBOSParameter() {
+            return null;
+        }
+
+        @Override
+        public short[] getEOSParameter() {
+            return null;
+        }
+
+        @Override
+        public CharacterCategory getCharacterCategory() {
+            CharacterCategory charCategory = new CharacterCategory();
+            try {
+                charCategory.readCharacterDefinition(
+                        DefaultInputTextPluginTest.class.getClassLoader().getResource("char.def").getPath());
+            } catch (IOException ex) {
+                ex.printStackTrace();
+            }
+            return charCategory;
+        }
+
+        @Override
+        public void setCharacterCategory(CharacterCategory charCategory) {
+        }
+    }
+}

--- a/src/test/java/com/worksap/nlp/sudachi/IgnoreYomiganaPluginTest.java
+++ b/src/test/java/com/worksap/nlp/sudachi/IgnoreYomiganaPluginTest.java
@@ -177,6 +177,37 @@ public class IgnoreYomiganaPluginTest {
         assertThat(text.getOriginalIndex(24), is(8));
     }
 
+    @Test
+    public void doNotIgnoreTooLong() {
+        final String ORIGINAL_TEXT = "明日（いっしょに）行く";
+        final String NORMALIZED_TEXT = "明日（いっしょに）行く";
+        builder = new UTF8InputTextBuilder(ORIGINAL_TEXT, new MockGrammar());
+        plugin.rewrite(builder);
+        text = builder.build();
+
+        assertThat(text.getOriginalText(), is(ORIGINAL_TEXT));
+        assertThat(text.getText(), is(NORMALIZED_TEXT));
+        byte[] bytes = text.getByteText();
+        assertThat(bytes.length, is(33));
+        assertArrayEquals(new byte[] { (byte) 0xE6, (byte) 0x98, (byte) 0x8E, (byte) 0xE6, (byte) 0x97, (byte) 0xA5,
+                (byte) 0xEF, (byte) 0xBC, (byte) 0x88, (byte) 0xE3, (byte) 0x81, (byte) 0x84, (byte) 0xE3, (byte) 0x81,
+                (byte) 0xA3, (byte) 0xE3, (byte) 0x81, (byte) 0x97, (byte) 0xE3, (byte) 0x82, (byte) 0x87, (byte) 0xE3,
+                (byte) 0x81, (byte) 0xAB, (byte) 0xEF, (byte) 0xBC, (byte) 0x89, (byte) 0xE8, (byte) 0xA1, (byte) 0x8C,
+                (byte) 0xE3, (byte) 0x81, (byte) 0x8F }, bytes);
+        assertThat(text.getOriginalIndex(0), is(0));
+        assertThat(text.getOriginalIndex(3), is(1));
+        assertThat(text.getOriginalIndex(6), is(2));
+        assertThat(text.getOriginalIndex(9), is(3));
+        assertThat(text.getOriginalIndex(12), is(4));
+        assertThat(text.getOriginalIndex(15), is(5));
+        assertThat(text.getOriginalIndex(18), is(6));
+        assertThat(text.getOriginalIndex(21), is(7));
+        assertThat(text.getOriginalIndex(24), is(8));
+        assertThat(text.getOriginalIndex(27), is(9));
+        assertThat(text.getOriginalIndex(30), is(10));
+        assertThat(text.getOriginalIndex(33), is(11));
+    }
+
     class MockGrammar implements Grammar {
         @Override
         public int getPartOfSpeechSize() {

--- a/src/test/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPluginTest.java
+++ b/src/test/java/com/worksap/nlp/sudachi/ProlongedSoundMarkInputTextPluginTest.java
@@ -26,12 +26,17 @@ import java.util.List;
 import javax.json.JsonObject;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import com.worksap.nlp.sudachi.dictionary.CharacterCategory;
 import com.worksap.nlp.sudachi.dictionary.Grammar;
 
 public class ProlongedSoundMarkInputTextPluginTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     UTF8InputTextBuilder builder;
     UTF8InputText text;
@@ -39,9 +44,13 @@ public class ProlongedSoundMarkInputTextPluginTest {
 
     @Before
     public void setUp() throws IOException {
+        Utils.copyResource(temporaryFolder.getRoot().toPath(), "/system.dic", "/user.dic", "/joinnumeric/char.def",
+                "/unk.def");
+        String path = temporaryFolder.getRoot().getPath();
+        String jsonString = Utils.readAllResource("/sudachi.json");
+        Dictionary dict = new DictionaryFactory().create(path, jsonString);
         plugin = new ProlongedSoundMarkInputTextPlugin();
 
-        String jsonString = Utils.readAllResource("/sudachi.json");
         Settings settings = Settings.parseSettings(null, jsonString);
         List<JsonObject> list = settings.getList("inputTextPlugin", JsonObject.class);
         for (JsonObject p : list) {
@@ -52,7 +61,7 @@ public class ProlongedSoundMarkInputTextPluginTest {
         }
 
         try {
-            plugin.setUp();
+            plugin.setUp(((JapaneseDictionary) dict).grammar);
         } catch (IOException ex) {
             ex.printStackTrace();
         }

--- a/src/test/resources/sudachi.json
+++ b/src/test/resources/sudachi.json
@@ -6,7 +6,10 @@
       { "class" : "com.worksap.nlp.sudachi.DefaultInputTextPlugin" },
       { "class" : "com.worksap.nlp.sudachi.ProlongedSoundMarkInputTextPlugin",
           "prolongedSoundMarks": ["ー", "〜", "〰"],
-          "replacementSymbol": "ー"}
+          "replacementSymbol": "ー"},
+      { "class" : "com.worksap.nlp.sudachi.IgnoreYomiganaPlugin",
+          "leftBrackets": ["(", "（"],
+          "rightBrackets": [")", "）"]}
     ],
     "oovProviderPlugin" : [
         { "class" : "com.worksap.nlp.sudachi.SimpleOovProviderPlugin",

--- a/src/test/resources/sudachi.json
+++ b/src/test/resources/sudachi.json
@@ -9,7 +9,8 @@
           "replacementSymbol": "ー"},
       { "class" : "com.worksap.nlp.sudachi.IgnoreYomiganaPlugin",
           "leftBrackets": ["(", "（"],
-          "rightBrackets": [")", "）"]}
+          "rightBrackets": [")", "）"],
+          "maxYomiganaLength": 4}
     ],
     "oovProviderPlugin" : [
         { "class" : "com.worksap.nlp.sudachi.SimpleOovProviderPlugin",


### PR DESCRIPTION
Add a plugin that ignores the Yomigana written in brackets after the Kanji. (issue #52)
Hiragana or/and Katakana can be Yomigana.


The following is an example of settings.
```
{
  "class" : "com.worksap.nlp.sudachi.IgnoreYomiganaPlugin",
  "leftBrackets": ["(", "（"],
  "rightBrackets": [")", "）"]
}

```

With above setting example, the plugin rewrites input `徳島（とくしま）に行(い)く` to `徳島に行く` .


