### PR TITLE
Fix SentenceDetector causing StackOverflowError

### DIFF
--- a/src/main/java/com/worksap/nlp/sudachi/sentdetect/SentenceDetector.java
+++ b/src/main/java/com/worksap/nlp/sudachi/sentdetect/SentenceDetector.java
@@ -39,20 +39,20 @@ public class SentenceDetector {
         boolean hasNonBreakWord(int eos);
     }
 
-    private static final String PERIODS = "。|？|！|♪|…|\\?|\\!";
-    private static final String DOT = "(\\.|．)";
+    private static final String PERIODS = "。？！♪…\\?\\!";
+    private static final String DOT = "\\.．";
     private static final String CDOT = "・";
-    private static final String COMMA = "(,|，|、)";
+    private static final String COMMA = ",，、";
     private static final String BR_TAG = "(<br>|<BR>){2,}";
-    private static final String ALPHABET_OR_NUMBER = "[a-z]|[A-Z]|[0-9]|[ａ-ｚ]|[Ａ-Ｚ]|[０-９]|〇|一|二|三|四|五|六|七|八|九|十|百|千|万|億|兆";
+    private static final String ALPHABET_OR_NUMBER = "a-zA-Z0-9ａ-ｚＡ-Ｚ０-９〇一二三四五六七八九十百千万億兆";
     private static final Pattern SENTENCE_BREAKER_PATTERN = Pattern
-            .compile("(" + PERIODS + "|" + CDOT + "{3,}+|((?<!(" + ALPHABET_OR_NUMBER + "))" + DOT + "(?!("
-                    + ALPHABET_OR_NUMBER + "|" + COMMA + "))))(" + DOT + "|" + PERIODS + ")*|" + BR_TAG);
+            .compile("([" + PERIODS + "]|" + CDOT + "{3,}+|((?<!([" + ALPHABET_OR_NUMBER + "]))[" + DOT + "](?!(["
+                    + ALPHABET_OR_NUMBER + COMMA + "]))))([" + DOT + PERIODS + "])*|" + BR_TAG);
 
-    private static final String OPEN_PARENTHESIS = "\\(|\\{|｛|\\[|（|「|【|『|［|≪|〔|“";
-    private static final String CLOSE_PARENTHESIS = "\\)|\\}|\\]|）|」|｝|】|』|］|〕|≫|”";
+    private static final String OPEN_PARENTHESIS = "\\(\\{｛\\[（「【『［≪〔“";
+    private static final String CLOSE_PARENTHESIS = "\\)\\}\\]）」｝】』］〕≫”";
 
-    private static final String ITEMIZE_HEADER = "(" + ALPHABET_OR_NUMBER + ")" + "(" + DOT + ")";
+    private static final String ITEMIZE_HEADER = "([" + ALPHABET_OR_NUMBER + "])" + "([" + DOT + "])";
     private static final Pattern ITEMIZE_HEADER_PATTERN = Pattern.compile(ITEMIZE_HEADER);
 
     /** the default maximum length of a sentence */
@@ -83,7 +83,7 @@ public class SentenceDetector {
      * If {@code checker} is not @{code null}, it is used to determine if there is a
      * word that crosses the detected boundary, and if so, the next boundary is
      * returned.
-     * 
+     *
      * If there is no boundary, it returns a relatively harmless boundary as a
      * negative value.
      *
@@ -129,7 +129,7 @@ public class SentenceDetector {
     }
 
     private static final Pattern PARENTHESIS_PATTERN = Pattern
-            .compile("(" + OPEN_PARENTHESIS + ")|(" + CLOSE_PARENTHESIS + ")");
+            .compile("([" + OPEN_PARENTHESIS + "])|([" + CLOSE_PARENTHESIS + "])");
 
     int parenthesisLevel(CharSequence s) {
         Matcher matcher = PARENTHESIS_PATTERN.matcher(s);
@@ -147,16 +147,16 @@ public class SentenceDetector {
         return level;
     }
 
-    private static final Pattern PROHIBITED_BOS_PETTERN = Pattern
-            .compile("\\A(" + CLOSE_PARENTHESIS + "|" + COMMA + "|" + PERIODS + ")+");
+    private static final Pattern PROHIBITED_BOS_PATTERN = Pattern
+            .compile("\\A([" + CLOSE_PARENTHESIS + COMMA + PERIODS + "])+");
 
     int prohibitedBOS(CharSequence s) {
-        Matcher m = PROHIBITED_BOS_PETTERN.matcher(s);
+        Matcher m = PROHIBITED_BOS_PATTERN.matcher(s);
         return (m.find()) ? m.end() : 0;
     }
 
     private static final Pattern QUOTE_MARKER_PATTERN = Pattern
-            .compile("(！|？|\\!|\\?|" + CLOSE_PARENTHESIS + ")(と|っ|です)");
+            .compile("(！|？|\\!|\\?|[" + CLOSE_PARENTHESIS + "])(と|っ|です)");
     private static final Pattern EOS_ITEMIZE_HEADER_PATTERN = Pattern.compile(ITEMIZE_HEADER + "\\z");
 
     boolean isContinuousPhrase(CharSequence s, int eos) {

--- a/src/test/java/com/worksap/nlp/sudachi/sentdetect/SentenceDetectorTest.java
+++ b/src/test/java/com/worksap/nlp/sudachi/sentdetect/SentenceDetectorTest.java
@@ -22,6 +22,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collections;
+
 public class SentenceDetectorTest {
 
     private SentenceDetector detector;
@@ -55,6 +57,12 @@ public class SentenceDetectorTest {
         assertThat(detector.getEos("あいう.えお", null), is(4));
         assertThat(detector.getEos("3.141", null), is(-5));
         assertThat(detector.getEos("四百十．〇", null), is(-5));
+    }
+
+    @Test
+    public void getEOSWithManyPeriods() {
+        String sentence = "あいうえお" + String.join("", Collections.nCopies(4000, "！"));
+        assertThat(detector.getEos(sentence, null), is(4005));
     }
 
     @Test


### PR DESCRIPTION
Hello,
This pull request fixes the issue that SentenceDetector was causing StackOverflowError when it was fed with particular strings, such as strings followed by a lot of punctuations (`！`, about 2000 or more).

As far as my understanding goes, the issue was caused by the regex containing repetitive alternative path.
https://stackoverflow.com/questions/7509905/java-lang-stackoverflowerror-while-using-a-regex-to-parse-big-strings/7510006#7510006