### PR TITLE
more fixes for Windows builds

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,34 @@
+# Handle line endings automatically for files detected as text
+# and leave all files detected as binary untouched.
+* text=auto
+
+# Force the following filetypes to have unix eols, so Windows does not break them
+*.* text eol=lf
+
+#
+## These files are binary and should be left untouched
+#
+
+# (binary is a macro for -text -diff)
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.mov binary
+*.mp4 binary
+*.mp3 binary
+*.flv binary
+*.fla binary
+*.swf binary
+*.gz binary
+*.zip binary
+*.7z binary
+*.ttf binary
+*.eot binary
+*.woff binary
+*.pyc binary
+*.pdf binary
+*.ez binary
+*.bz2 binary
+*.swp binary

--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,14 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.0.0-M5</version>
+        <configuration>
+          <argLine>-Dfile.encoding=UTF-8</argLine>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>1.6.0</version>

--- a/src/main/java/com/worksap/nlp/sudachi/dictionary/DictionaryBuilder.java
+++ b/src/main/java/com/worksap/nlp/sudachi/dictionary/DictionaryBuilder.java
@@ -123,7 +123,7 @@ public class DictionaryBuilder {
 
     void buildLexicon(String filename, FileInputStream lexiconInput) throws IOException {
         int lineno = -1;
-        try (InputStreamReader isr = new InputStreamReader(lexiconInput);
+        try (InputStreamReader isr = new InputStreamReader(lexiconInput, StandardCharsets.UTF_8);
                 LineNumberReader reader = new LineNumberReader(isr);
                 CSVParser parser = new CSVParser(reader)) {
             for (List<String> columns = parser.getNextRecord(); columns != null; columns = parser.getNextRecord()) {


### PR DESCRIPTION
1. .gitattributes fixes the problem with spotless:apply,
wanting to insert \r\n in every line on windows
2. Explicitly specify file encoding for tests and dictionary building