### PR TITLE
redo more fixes for Windows builds

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,34 @@
+# Handle line endings automatically for files detected as text
+# and leave all files detected as binary untouched.
+* text=auto
+
+# Force the following filetypes to have unix eols, so Windows does not break them
+*.* text eol=lf
+
+#
+## These files are binary and should be left untouched
+#
+
+# (binary is a macro for -text -diff)
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.mov binary
+*.mp4 binary
+*.mp3 binary
+*.flv binary
+*.fla binary
+*.swf binary
+*.gz binary
+*.zip binary
+*.7z binary
+*.ttf binary
+*.eot binary
+*.woff binary
+*.pyc binary
+*.pdf binary
+*.ez binary
+*.bz2 binary
+*.swp binary

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,10 @@ local.properties
 # JDT-specific (Eclipse Java Development Tools)		
 .classpath
 
+### IntelliJ-based IDEs
+
+.idea/
+
 ### Java ###
 # Compiled class file
 *.class

--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,14 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.2</version>
+        <configuration>
+          <argLine>-Dfile.encoding=UTF-8</argLine>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>1.6.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <sonar.links.issue>https://github.com/WorksApplications/Sudachi/issues</sonar.links.issue>
     <sonar.junit.reportsPath />
     <sonar.junit.reportPaths>${project.build.directory}/surefire-reports</sonar.junit.reportPaths>
+    <argLine></argLine>
   </properties>
 
   <profiles>
@@ -161,9 +162,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>3.0.0-M5</version>
         <configuration>
-          <argLine>-Dfile.encoding=UTF-8</argLine>
+          <argLine>@{argLine} -Dfile.encoding=UTF-8</argLine>
         </configuration>
       </plugin>
       <plugin>
@@ -247,12 +248,12 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.4</version>
+        <version>0.8.7</version>
       </plugin>
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
-        <version>2.9.0</version>
+        <version>2.17.6</version>
         <configuration>
           <java>
             <eclipse>

--- a/src/main/java/com/worksap/nlp/sudachi/dictionary/DictionaryBuilder.java
+++ b/src/main/java/com/worksap/nlp/sudachi/dictionary/DictionaryBuilder.java
@@ -123,7 +123,7 @@ public class DictionaryBuilder {
 
     void buildLexicon(String filename, FileInputStream lexiconInput) throws IOException {
         int lineno = -1;
-        try (InputStreamReader isr = new InputStreamReader(lexiconInput);
+        try (InputStreamReader isr = new InputStreamReader(lexiconInput, StandardCharsets.UTF_8);
                 LineNumberReader reader = new LineNumberReader(isr);
                 CSVParser parser = new CSVParser(reader)) {
             for (List<String> columns = parser.getNextRecord(); columns != null; columns = parser.getNextRecord()) {


### PR DESCRIPTION
1. .gitattributes fixes the problem with spotless:apply,
wanting to insert \r\n in every line on Windows
2. Explicitly specify file encoding for tests and dictionary building