### PR TITLE
Speedup binary dictionary lookup

### DIFF
--- a/src/jmh/java/com/worksap/nlp/sudachi/dictionary/DoubleArrayLookupBench.java
+++ b/src/jmh/java/com/worksap/nlp/sudachi/dictionary/DoubleArrayLookupBench.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2022 Works Applications Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.worksap.nlp.sudachi.dictionary;
+
+import com.worksap.nlp.dartsclone.DoubleArray;
+import com.worksap.nlp.sudachi.MMap;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.nio.IntBuffer;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.zip.GZIPInputStream;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Warmup(time = 5, iterations = 3)
+@Measurement(iterations = 7, time = 5)
+@Fork(value = 1)
+public class DoubleArrayLookupBench {
+    private List<byte[]> keyCandidates;
+
+    private final DoubleArray originalImpl = new DoubleArray();
+    private DoubleArrayLookup newImpl;
+
+    @Setup()
+    public void setup() throws IOException {
+        Path keysFile = Paths.get("build/darray/keys.txt");
+        if (Files.notExists(keysFile)) {
+            // download from internet if not exists
+            Files.createDirectories(keysFile.getParent());
+            // Sudachi Dictionary keys for all words (full dictionary)
+            URL keysUrl = new URL("https://github.com/eiennohito/xtime/releases/download/v0.0.1/keys.txt.gz");
+            try (InputStream is = keysUrl.openStream()) {
+                GZIPInputStream gzipStream = new GZIPInputStream(is);
+                Files.copy(gzipStream, keysFile);
+            }
+        }
+        keyCandidates = Files.lines(keysFile).map(l -> l.getBytes(StandardCharsets.UTF_8)).collect(Collectors.toList());
+        keyCandidates.sort((a, b) -> {
+            int len = Math.min(a.length, b.length);
+            for (int i = 0; i < len; ++i) {
+                int xa = Byte.toUnsignedInt(a[i]);
+                int xb = Byte.toUnsignedInt(b[i]);
+                int cmp = Integer.compare(xa, xb);
+                if (cmp != 0) {
+                    return cmp;
+                }
+            }
+            return Integer.compare(a.length, b.length);
+        });
+        Path binfile = Paths.get("build/darray/keys.darray");
+        ByteBuffer buffer;
+        IntBuffer dataAsInts;
+        if (Files.exists(binfile)) {
+            buffer = MMap.map(binfile);
+            dataAsInts = buffer.asIntBuffer();
+            originalImpl.setArray(dataAsInts, buffer.limit() / 4);
+        } else {
+            byte[][] keys = keyCandidates.toArray(new byte[0][]);
+            int[] values = IntStream.range(0, keys.length).toArray();
+            originalImpl.build(keys, values, null);
+            try (SeekableByteChannel channel = Files.newByteChannel(binfile, StandardOpenOption.CREATE,
+                    StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE)) {
+                channel.write(originalImpl.byteArray());
+            }
+            dataAsInts = originalImpl.array();
+        }
+        newImpl = new DoubleArrayLookup(dataAsInts);
+    }
+
+    @State(Scope.Thread)
+    public static class KeysToLookup {
+        private final ArrayList<byte[]> keys = new ArrayList<>();
+        private final Random rng = new Random(0xdeadbeefL);
+
+        @Setup(Level.Invocation)
+        public void setup(DoubleArrayLookupBench lookup) {
+            int numKeys = 1000;
+            keys.clear();
+            rng.ints(numKeys, 0, lookup.keyCandidates.size()).forEach(i -> keys.add(lookup.keyCandidates.get(i)));
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(1000)
+    public void traverseTrieOriginalImpl(KeysToLookup toLookup, Blackhole blackhole) {
+        for (byte[] key : toLookup.keys) {
+            Iterator<int[]> iter = originalImpl.commonPrefixSearch(key, 0);
+            while (iter.hasNext()) {
+                int[] data = iter.next();
+                blackhole.consume(data[0]);
+                blackhole.consume(data[1]);
+            }
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(1000)
+    public void traverseTrieNewImpl(KeysToLookup toLookup, Blackhole blackhole) {
+        DoubleArrayLookup lookup = this.newImpl;
+        for (byte[] key : toLookup.keys) {
+            lookup.reset(key, 0, key.length);
+            while (lookup.next()) {
+                blackhole.consume(lookup.getValue());
+                blackhole.consume(lookup.getOffset());
+            }
+        }
+    }
+}

--- a/src/main/java/com/worksap/nlp/sudachi/JapaneseTokenizer.java
+++ b/src/main/java/com/worksap/nlp/sudachi/JapaneseTokenizer.java
@@ -243,11 +243,11 @@ class JapaneseTokenizer implements Tokenizer {
                 int[] wordIds = wordLookup.getWordsIds();
                 for (int word = 0; word < numWords; ++word) {
                     int wordId = wordIds[word];
-                    LatticeNode n = new LatticeNodeImpl(lexicon, lexicon.getLeftId(wordId), lexicon.getRightId(wordId),
-                            lexicon.getCost(wordId), wordId);
+                    LatticeNodeImpl n = new LatticeNodeImpl(lexicon, lexicon.getLeftId(wordId),
+                            lexicon.getRightId(wordId), lexicon.getCost(wordId), wordId);
                     lattice.insert(byteBoundary, end, n);
                     unkNodes.add(n);
-                    wordMask = WordMask.addNth(wordMask, end - i);
+                    wordMask = WordMask.addNth(wordMask, end - byteBoundary);
                 }
             }
             long wordMaskWithOov = wordMask;

--- a/src/main/java/com/worksap/nlp/sudachi/WordId.java
+++ b/src/main/java/com/worksap/nlp/sudachi/WordId.java
@@ -31,7 +31,7 @@ public class WordId {
     public static final int MAX_DIC_ID = 0xe;
 
     public static int makeUnchecked(int dic, int word) {
-        int dicPart = dic << 28;
+        int dicPart = dicIdMask(dic);
         return dicPart | word;
     }
 
@@ -75,5 +75,13 @@ public class WordId {
      */
     public static int word(int wordId) {
         return wordId & MAX_WORD_ID;
+    }
+
+    public static int dicIdMask(int dicId) {
+        return dicId << 28;
+    }
+
+    public static int applyMask(int wordId, int dicIdMask) {
+        return (wordId & MAX_WORD_ID) | dicIdMask;
     }
 }

--- a/src/main/java/com/worksap/nlp/sudachi/dictionary/DoubleArrayLexicon.java
+++ b/src/main/java/com/worksap/nlp/sudachi/dictionary/DoubleArrayLexicon.java
@@ -29,10 +29,10 @@ public class DoubleArrayLexicon implements Lexicon {
 
     static final int USER_DICT_COST_PAR_MORPH = -20;
 
-    private WordIdTable wordIdTable;
-    private WordParameterList wordParams;
-    private WordInfoList wordInfos;
-    private DoubleArray trie;
+    private final WordIdTable wordIdTable;
+    private final WordParameterList wordParams;
+    private final WordInfoList wordInfos;
+    private final DoubleArray trie;
 
     public DoubleArrayLexicon(ByteBuffer bytes, int offset, boolean hasSynonymGid) {
         trie = new DoubleArray();
@@ -75,6 +75,14 @@ public class DoubleArrayLexicon implements Lexicon {
             return iterator;
         }
         return new Itr(iterator);
+    }
+
+    public IntBuffer getTrieArray() {
+        return trie.array();
+    }
+
+    public WordIdTable getWordIdTable() {
+        return wordIdTable;
     }
 
     private class Itr implements Iterator<int[]> {
@@ -167,4 +175,9 @@ public class DoubleArrayLexicon implements Lexicon {
             wordParams.setCost(wordId, (short) cost);
         }
     }
+
+    public void setDictionaryId(int id) {
+        wordIdTable.setDictionaryId(id);
+    }
+
 }

--- a/src/main/java/com/worksap/nlp/sudachi/dictionary/DoubleArrayLookup.java
+++ b/src/main/java/com/worksap/nlp/sudachi/dictionary/DoubleArrayLookup.java
@@ -18,6 +18,12 @@ package com.worksap.nlp.sudachi.dictionary;
 
 import java.nio.IntBuffer;
 
+/**
+ * This class implements common prefix lookup in the double array with a
+ * different API. It uses fields to return current values of end offset and a
+ * value stored in trie to reduce GC pressure. It also modifies the hot loop to
+ * reduce the number of non-elidable field writes.
+ */
 public final class DoubleArrayLookup {
     private IntBuffer array;
     private byte[] key;

--- a/src/main/java/com/worksap/nlp/sudachi/dictionary/DoubleArrayLookup.java
+++ b/src/main/java/com/worksap/nlp/sudachi/dictionary/DoubleArrayLookup.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2022 Works Applications Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.worksap.nlp.sudachi.dictionary;
+
+import java.nio.IntBuffer;
+
+public final class DoubleArrayLookup {
+    private IntBuffer array;
+    private byte[] key;
+    private int limit;
+    private int startOffset;
+    private int offset;
+    private int nodePos;
+    private int nodeValue;
+
+    public DoubleArrayLookup() {
+        this(null);
+    }
+
+    public DoubleArrayLookup(IntBuffer array) {
+        this.array = array;
+    }
+
+    public DoubleArrayLookup(IntBuffer array, byte[] key, int offset, int limit) {
+        this(array);
+        reset(key, offset, limit);
+    }
+
+    private static boolean hasLeaf(int unit) {
+        return ((unit >>> 8) & 1) == 1;
+    }
+
+    private static int value(int unit) {
+        return unit & ((1 << 31) - 1);
+    }
+
+    private static int label(int unit) {
+        return unit & ((1 << 31) | 0xFF);
+    }
+
+    private static int offset(int unit) {
+        return ((unit >>> 10) << ((unit & (1 << 9)) >>> 6));
+    }
+
+    public void setArray(IntBuffer array) {
+        this.array = array;
+        reset(this.key, this.startOffset, this.limit);
+    }
+
+    public void reset(byte[] key, int offset, int limit) {
+        this.key = key;
+        this.offset = offset;
+        this.startOffset = offset;
+        this.limit = limit;
+        nodePos = 0;
+        int unit = array.get(nodePos);
+        nodePos ^= offset(unit);
+    }
+
+    public boolean next() {
+        IntBuffer array = this.array;
+        byte[] key = this.key;
+        int nodePos = this.nodePos;
+        int limit = this.limit;
+
+        for (int offset = this.offset; offset < limit; ++offset) {
+            int k = Byte.toUnsignedInt(key[offset]);
+            nodePos ^= k;
+            int unit = array.get(nodePos);
+            if (label(unit) != k) {
+                this.offset = limit; // no more loop
+                this.nodePos = nodePos;
+                return false;
+            }
+
+            nodePos ^= offset(unit);
+            if (hasLeaf(unit)) {
+                nodeValue = value(array.get(nodePos));
+                this.offset = offset + 1;
+                this.nodePos = nodePos;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public int getValue() {
+        return nodeValue;
+    }
+
+    public int getOffset() {
+        return offset;
+    }
+}

--- a/src/main/java/com/worksap/nlp/sudachi/dictionary/LexiconSet.java
+++ b/src/main/java/com/worksap/nlp/sudachi/dictionary/LexiconSet.java
@@ -23,16 +23,17 @@ import java.util.*;
 public class LexiconSet implements Lexicon {
     static final int MAX_DICTIONARIES = 15;
 
-    List<Lexicon> lexicons = new ArrayList<>();
+    List<DoubleArrayLexicon> lexicons = new ArrayList<>();
     List<Short> posOffsets = new ArrayList<>();
 
     public LexiconSet(Lexicon systemLexicon) {
-        lexicons.add(systemLexicon);
-        posOffsets.add((short) 0);
+        add(systemLexicon, (short) 0);
     }
 
     public void add(Lexicon lexicon, short posOffset) {
-        lexicons.add(lexicon);
+        DoubleArrayLexicon daLexicon = (DoubleArrayLexicon) lexicon;
+        daLexicon.setDictionaryId(lexicons.size());
+        lexicons.add(daLexicon);
         posOffsets.add(posOffset);
     }
 
@@ -165,5 +166,9 @@ public class LexiconSet implements Lexicon {
                 split[i] = buildWordId(dictionaryId, getWordId(split[i]));
             }
         }
+    }
+
+    public WordLookup makeLookup() {
+        return new WordLookup(this.lexicons);
     }
 }

--- a/src/main/java/com/worksap/nlp/sudachi/dictionary/WordIdTable.java
+++ b/src/main/java/com/worksap/nlp/sudachi/dictionary/WordIdTable.java
@@ -46,12 +46,21 @@ class WordIdTable {
         return result;
     }
 
-    int fillBuffer(int index, WordLookup lookup) {
+    /**
+     * Reads the word IDs to the passed WordLookup object
+     * 
+     * @param index
+     *            index in the word array
+     * @param lookup
+     *            object to read word IDs into
+     * @return number of read IDs
+     */
+    int readWordIds(int index, WordLookup lookup) {
         int offset = this.offset + index;
         ByteBuffer bytes = this.bytes;
         int length = Byte.toUnsignedInt(bytes.get(offset));
         offset += 1;
-        int[] result = lookup.prepare(length);
+        int[] result = lookup.outputBuffer(length);
         int dicIdMask = this.dicIdMask;
         for (int i = 0; i < length; i++) {
             int wordId = bytes.getInt(offset);

--- a/src/main/java/com/worksap/nlp/sudachi/dictionary/WordIdTable.java
+++ b/src/main/java/com/worksap/nlp/sudachi/dictionary/WordIdTable.java
@@ -16,13 +16,15 @@
 
 package com.worksap.nlp.sudachi.dictionary;
 
+import com.worksap.nlp.sudachi.WordId;
+
 import java.nio.ByteBuffer;
 
 class WordIdTable {
-
     private final ByteBuffer bytes;
     private final int size;
     private final int offset;
+    private int dicIdMask = 0;
 
     WordIdTable(ByteBuffer bytes, int offset) {
         this.bytes = bytes;
@@ -42,5 +44,24 @@ class WordIdTable {
             index += 4;
         }
         return result;
+    }
+
+    int fillBuffer(int index, WordLookup lookup) {
+        int offset = this.offset + index;
+        ByteBuffer bytes = this.bytes;
+        int length = Byte.toUnsignedInt(bytes.get(offset));
+        offset += 1;
+        int[] result = lookup.prepare(length);
+        int dicIdMask = this.dicIdMask;
+        for (int i = 0; i < length; i++) {
+            int wordId = bytes.getInt(offset);
+            result[i] = WordId.applyMask(wordId, dicIdMask);
+            offset += 4;
+        }
+        return length;
+    }
+
+    void setDictionaryId(int id) {
+        dicIdMask = WordId.dicIdMask(id);
     }
 }

--- a/src/main/java/com/worksap/nlp/sudachi/dictionary/WordLookup.java
+++ b/src/main/java/com/worksap/nlp/sudachi/dictionary/WordLookup.java
@@ -70,7 +70,7 @@ public final class WordLookup {
      *            minimum requested length
      * @return WordId array
      */
-    public int[] prepare(int length) {
+    public int[] outputBuffer(int length) {
         if (wordIds.length < length) {
             wordIds = Arrays.copyOf(wordIds, Math.max(length, wordIds.length * 2));
         }
@@ -92,7 +92,7 @@ public final class WordLookup {
             currentLexicon = nextLexicon;
         }
         int wordGroupId = lookup.getValue();
-        numWords = words.fillBuffer(wordGroupId, this);
+        numWords = words.readWordIds(wordGroupId, this);
         return true;
     }
 

--- a/src/main/java/com/worksap/nlp/sudachi/dictionary/WordLookup.java
+++ b/src/main/java/com/worksap/nlp/sudachi/dictionary/WordLookup.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2022 Works Applications Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.worksap.nlp.sudachi.dictionary;
+
+import java.util.Arrays;
+import java.util.List;
+
+public final class WordLookup {
+    private final DoubleArrayLookup lookup = new DoubleArrayLookup();
+    private WordIdTable words;
+    // initial size 16 - one cache line (64 bytes) on most modern CPUs
+    private int[] wordIds = new int[16];
+    private int numWords;
+    private final List<DoubleArrayLexicon> lexicons;
+    private int currentLexicon = -1;
+
+    public WordLookup(List<DoubleArrayLexicon> lexicons) {
+        this.lexicons = lexicons;
+    }
+
+    private void rebind(DoubleArrayLexicon lexicon) {
+        lookup.setArray(lexicon.getTrieArray());
+        words = lexicon.getWordIdTable();
+    }
+
+    public void reset(byte[] key, int offset, int limit) {
+        currentLexicon = lexicons.size() - 1;
+        rebind(lexicons.get(currentLexicon));
+        lookup.reset(key, offset, limit);
+    }
+
+    public int[] prepare(int length) {
+        if (wordIds.length < length) {
+            wordIds = Arrays.copyOf(wordIds, Math.max(length, wordIds.length * 2));
+        }
+        return wordIds;
+    }
+
+    public boolean next() {
+        while (!lookup.next()) {
+            int nextLexicon = currentLexicon - 1;
+            if (nextLexicon < 0) {
+                return false;
+            }
+            rebind(lexicons.get(nextLexicon));
+            currentLexicon = nextLexicon;
+        }
+        int wordGroupId = lookup.getValue();
+        numWords = words.fillBuffer(wordGroupId, this);
+        return true;
+    }
+
+    public int getEndOffset() {
+        return lookup.getOffset();
+    }
+
+    public int getNumWords() {
+        return numWords;
+    }
+
+    public int[] getWordsIds() {
+        return wordIds;
+    }
+}

--- a/src/main/java/com/worksap/nlp/sudachi/dictionary/WordLookup.java
+++ b/src/main/java/com/worksap/nlp/sudachi/dictionary/WordLookup.java
@@ -16,9 +16,18 @@
 
 package com.worksap.nlp.sudachi.dictionary;
 
+import com.worksap.nlp.sudachi.WordId;
+
 import java.util.Arrays;
 import java.util.List;
 
+/**
+ * This class is an abstraction for looking up words in a list of binary
+ * dictionaries. It returns a list of WordIds for each matching key in the Trie
+ * index. WordIds are stored in a plain int array to remove any possible boxing.
+ * Memory for the lookup is kept for a single analysis step to decrease garbage
+ * collection pressure.
+ */
 public final class WordLookup {
     private final DoubleArrayLookup lookup = new DoubleArrayLookup();
     private WordIdTable words;
@@ -37,12 +46,30 @@ public final class WordLookup {
         words = lexicon.getWordIdTable();
     }
 
+    /**
+     * Start the search for new key
+     * 
+     * @param key
+     *            utf-8 bytes corresponding to the trie key
+     * @param offset
+     *            offset of key start
+     * @param limit
+     *            offset of key end
+     */
     public void reset(byte[] key, int offset, int limit) {
         currentLexicon = lexicons.size() - 1;
         rebind(lexicons.get(currentLexicon));
         lookup.reset(key, offset, limit);
     }
 
+    /**
+     * This is not public API. Returns the array for wordIds with the length at
+     * least equal to the passed parameter
+     * 
+     * @param length
+     *            minimum requested length
+     * @return WordId array
+     */
     public int[] prepare(int length) {
         if (wordIds.length < length) {
             wordIds = Arrays.copyOf(wordIds, Math.max(length, wordIds.length * 2));
@@ -50,6 +77,11 @@ public final class WordLookup {
         return wordIds;
     }
 
+    /**
+     * Sets the wordIds, numWords, endOffset to the
+     * 
+     * @return true if there was an entry in any of binary dictionaries
+     */
     public boolean next() {
         while (!lookup.next()) {
             int nextLexicon = currentLexicon - 1;
@@ -64,14 +96,30 @@ public final class WordLookup {
         return true;
     }
 
+    /**
+     * Returns trie key end offset
+     * 
+     * @return number of utf-8 bytes corresponding to the end of key
+     */
     public int getEndOffset() {
         return lookup.getOffset();
     }
 
+    /**
+     *
+     * @return number of currently correct entries in the wordIds
+     */
     public int getNumWords() {
         return numWords;
     }
 
+    /**
+     * Returns array of word ids. Number of correct entries is specified by
+     * {@link #getNumWords()}. WordIds have their dictionary part set.
+     * 
+     * @return array consisting word ids for the current index entry
+     * @see WordId
+     */
     public int[] getWordsIds() {
         return wordIds;
     }

--- a/src/main/java/com/worksap/nlp/sudachi/dictionary/build/DicBuilder.java
+++ b/src/main/java/com/worksap/nlp/sudachi/dictionary/build/DicBuilder.java
@@ -58,8 +58,8 @@ public class DicBuilder {
             return new WordLookup.Csv(lexicon);
         }
 
+        @SuppressWarnings("unchecked")
         private T self() {
-            // noinspection unchecked
             return (T) this;
         }
 


### PR DESCRIPTION
Gives ~5% global analysis speedup. Mostly removes boxing overhead and GC pressure which is not visible in single-threaded workloads, but should help with high-load usages e.g. during heavy multithreaded index creation in ElasticSearch.

Low-level dictionary lookup was reimplemented in Sudachi and probably should be moved into darts-clone, but that will be a breaking API change.

Log of JMH output of the new benchmark with GC profiler: https://gist.github.com/eiennohito/a8ab478bb3ea9200aa37eb545c3bdd3a

```
Benchmark                                                                          Mode  Cnt     Score    Error   Units
DoubleArrayLookupBench.traverseTrieNewImpl                                        thrpt    7  2182.249 ± 14.876  ops/ms
DoubleArrayLookupBench.traverseTrieNewImpl:·gc.alloc.rate                         thrpt    7     0.187 ±  0.001  MB/sec
DoubleArrayLookupBench.traverseTrieNewImpl:·gc.alloc.rate.norm                    thrpt    7     0.120 ±  0.001    B/op
DoubleArrayLookupBench.traverseTrieNewImpl:·gc.count                              thrpt    7       ≈ 0           counts
DoubleArrayLookupBench.traverseTrieOriginalImpl                                   thrpt    7  2114.092 ± 26.789  ops/ms
DoubleArrayLookupBench.traverseTrieOriginalImpl:·gc.alloc.rate                    thrpt    7   134.543 ±  1.727  MB/sec
DoubleArrayLookupBench.traverseTrieOriginalImpl:·gc.alloc.rate.norm               thrpt    7    88.816 ±  0.024    B/op
DoubleArrayLookupBench.traverseTrieOriginalImpl:·gc.churn.G1_Eden_Space           thrpt    7   130.552 ± 63.111  MB/sec
DoubleArrayLookupBench.traverseTrieOriginalImpl:·gc.churn.G1_Eden_Space.norm      thrpt    7    86.238 ± 42.374    B/op
DoubleArrayLookupBench.traverseTrieOriginalImpl:·gc.churn.G1_Survivor_Space       thrpt    7     0.304 ±  1.595  MB/sec
DoubleArrayLookupBench.traverseTrieOriginalImpl:·gc.churn.G1_Survivor_Space.norm  thrpt    7     0.200 ±  1.050    B/op
DoubleArrayLookupBench.traverseTrieOriginalImpl:·gc.count                         thrpt    7    17.000           counts
DoubleArrayLookupBench.traverseTrieOriginalImpl:·gc.time                          thrpt    7    67.000               ms
```

There is marginal improvement in trie traversal itself, but GC pressure is greatly decreased.