### PR TITLE
Add regex oov plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,7 @@ settings.xml
 build/
 .gradle/
 !gradle/wrapper/gradle-wrapper.jar
+out/
 
 ### OSX ###
 *.DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -5,13 +5,13 @@
 plugins {
     id 'java'
     id 'maven-publish'
-    id 'org.jetbrains.kotlin.jvm' version '1.6.10' // only for tests, see gradle.properties
+    id 'org.jetbrains.kotlin.jvm' version '1.6.21' // only for tests, see gradle.properties
     id 'jacoco'
     id 'org.sonarqube' version '3.3'
-    id 'com.diffplug.spotless' version '6.1.2'
+    id 'com.diffplug.spotless' version '6.6.1'
     id 'distribution'
     id 'signing'
-    id "me.champeau.jmh" version "0.6.6"
+    id 'me.champeau.jmh' version "0.6.6"
 }
 
 repositories {
@@ -25,10 +25,10 @@ dependencies {
     testImplementation 'org.hamcrest:hamcrest:2.2'
     testImplementation 'org.hamcrest:hamcrest-library:2.2'
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.openjdk.jmh:jmh-core:1.34'
-    testImplementation 'org.openjdk.jmh:jmh-generator-annprocess:1.34'
-    testImplementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.10'
-    testImplementation 'org.jetbrains.kotlin:kotlin-test-junit:1.6.10'
+    testImplementation 'org.openjdk.jmh:jmh-core:1.35'
+    testImplementation 'org.openjdk.jmh:jmh-generator-annprocess:1.35'
+    testImplementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21'
+    testImplementation 'org.jetbrains.kotlin:kotlin-test-junit:1.6.21'
 }
 
 group = 'com.worksap.nlp'
@@ -79,12 +79,13 @@ spotless {
     }
     java {
         // don't need to set target, it is inferred from java
+        // version list: https://github.com/diffplug/spotless/tree/main/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter
         eclipse('4.21.0').configFile('.formatter/eclipse-formatter.xml')
         licenseHeaderFile('.formatter/license-header')
     }
     kotlin {
         // by default the target is every '.kt' and '.kts` file in the java sourcesets
-        ktfmt('0.30')
+        ktfmt('0.36')
         licenseHeaderFile('.formatter/license-header')
     }
 }

--- a/src/main/java/com/worksap/nlp/sudachi/Config.java
+++ b/src/main/java/com/worksap/nlp/sudachi/Config.java
@@ -20,6 +20,7 @@ import com.worksap.nlp.sudachi.dictionary.BinaryDictionary;
 import com.worksap.nlp.sudachi.dictionary.CharacterCategory;
 
 import javax.json.Json;
+import javax.json.JsonArrayBuilder;
 import javax.json.JsonObject;
 import java.io.IOException;
 import java.io.InputStream;
@@ -680,18 +681,49 @@ public class Config {
         }
 
         /**
-         * Add untyped key-value configuration to the plugin
+         * Add a string value to the plugin configuration
          * 
          * @param key
          *            setting key
          * @param value
          *            setting value
-         * @return modified plugin
+         * @return current plugin instance
          */
         public PluginConf<T> add(String key, String value) {
             JsonObject obj = Json.createObjectBuilder().add(key, value).build();
-            Settings merged = internal.merge(new Settings(obj, SettingsAnchor.none()));
-            return new PluginConf<>(clazzName, merged, parent);
+            internal = internal.merge(new Settings(obj, SettingsAnchor.none()));
+            return this;
+        }
+
+        /**
+         * Add an int value to the plugin configuration
+         * 
+         * @param key
+         *            setting key
+         * @param value
+         *            setting value
+         * @return current plugin instance
+         */
+        public PluginConf<T> add(String key, int value) {
+            JsonObject obj = Json.createObjectBuilder().add(key, value).build();
+            internal = internal.merge(new Settings(obj, SettingsAnchor.none()));
+            return this;
+        }
+
+        /**
+         * Add a string list value to the plugin configuration
+         * 
+         * @param key
+         *            setting key
+         * @param values
+         *            setting value as a string array
+         * @return current plugin instance
+         */
+        public PluginConf<T> addList(String key, String... values) {
+            JsonArrayBuilder builder = Json.createArrayBuilder(Arrays.asList(values));
+            JsonObject obj = Json.createObjectBuilder().add(key, builder).build();
+            internal = internal.merge(new Settings(obj, SettingsAnchor.none()));
+            return this;
         }
     }
 

--- a/src/main/java/com/worksap/nlp/sudachi/DictionaryFactory.java
+++ b/src/main/java/com/worksap/nlp/sudachi/DictionaryFactory.java
@@ -62,7 +62,7 @@ public class DictionaryFactory {
     @Deprecated()
     public Dictionary create(String settings) throws IOException {
         Config defaults = Config.fromClasspath();
-        Config passed = Config.fromJsonString(settings, SettingsAnchor.none());
+        Config passed = Config.fromJsonString(settings, SettingsAnchor.classpath().andThen(SettingsAnchor.none()));
         Config merged = defaults.merge(passed, Config.MergeMode.REPLACE);
         return create(merged);
     }

--- a/src/main/java/com/worksap/nlp/sudachi/InputText.java
+++ b/src/main/java/com/worksap/nlp/sudachi/InputText.java
@@ -201,4 +201,21 @@ public interface InputText {
      * @return the index of the character
      */
     public int getNextInOriginal(int index);
+
+    /**
+     * Returns utf-16 code unit offset in the modified sequence based on byte
+     * offset.
+     * 
+     * @param index
+     *            offset in utf-8 bytes
+     * @return offset in utf-16 code units
+     */
+    int modifiedOffset(int index);
+
+    /**
+     * Get utf-8 representation of input text
+     * 
+     * @return bytes of utf-8 representation
+     */
+    byte[] getByteText();
 }

--- a/src/main/java/com/worksap/nlp/sudachi/MeCabOovProviderPlugin.java
+++ b/src/main/java/com/worksap/nlp/sudachi/MeCabOovProviderPlugin.java
@@ -16,22 +16,17 @@
 
 package com.worksap.nlp.sudachi;
 
-import java.io.FileInputStream;
+import com.worksap.nlp.sudachi.dictionary.CategoryType;
+import com.worksap.nlp.sudachi.dictionary.Grammar;
+import com.worksap.nlp.sudachi.dictionary.WordInfo;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.EnumMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.regex.Pattern;
-
-import com.worksap.nlp.sudachi.dictionary.CategoryType;
-import com.worksap.nlp.sudachi.dictionary.Grammar;
-import com.worksap.nlp.sudachi.dictionary.WordInfo;
 
 /**
  * Provides the OOVs in the same way as MeCab.

--- a/src/main/java/com/worksap/nlp/sudachi/MeCabOovProviderPlugin.java
+++ b/src/main/java/com/worksap/nlp/sudachi/MeCabOovProviderPlugin.java
@@ -77,16 +77,16 @@ class MeCabOovProviderPlugin extends OovProviderPlugin {
 
     @Override
     public void setUp(Grammar grammar) throws IOException {
-        String charDef = settings.getPath("charDef");
+        Config.Resource<Object> charDef = settings.getResource("charDef");
         readCharacterProperty(charDef);
-        String unkDef = settings.getPath("unkDef");
+        Config.Resource<Object> unkDef = settings.getResource("unkDef");
         readOOV(unkDef, grammar);
     }
 
     @Override
-    public List<LatticeNode> provideOOV(InputText inputText, int offset, boolean hasOtherWords) {
-        List<LatticeNode> nodes = new ArrayList<>();
+    public int provideOOV(InputText inputText, int offset, long otherWords, List<LatticeNodeImpl> nodes) {
         int length = inputText.getCharCategoryContinuousLength(offset);
+        int added = 0;
         if (length > 0) {
             for (CategoryType type : inputText.getCharCategoryTypes(offset)) {
                 CategoryInfo cinfo = categories.get(type);
@@ -98,14 +98,15 @@ class MeCabOovProviderPlugin extends OovProviderPlugin {
                 if (oovs == null) {
                     continue;
                 }
-                if (cinfo.isGroup && (cinfo.isInvoke || !hasOtherWords)) {
+                if (cinfo.isGroup && (cinfo.isInvoke || otherWords == 0)) {
                     String s = inputText.getSubstring(offset, offset + length);
                     for (OOV oov : oovs) {
                         nodes.add(getOOVNode(s, oov, length));
+                        added += 1;
                     }
                     llength -= 1;
                 }
-                if (cinfo.isInvoke || !hasOtherWords) {
+                if (cinfo.isInvoke || otherWords == 0) {
                     for (int i = 1; i <= cinfo.length; i++) {
                         int sublength = inputText.getCodePointsOffsetLength(offset, i);
                         if (sublength > llength) {
@@ -114,16 +115,17 @@ class MeCabOovProviderPlugin extends OovProviderPlugin {
                         String s = inputText.getSubstring(offset, offset + sublength);
                         for (OOV oov : oovs) {
                             nodes.add(getOOVNode(s, oov, sublength));
+                            added += 1;
                         }
                     }
                 }
             }
         }
-        return nodes;
+        return added;
     }
 
-    LatticeNode getOOVNode(String text, OOV oov, int length) {
-        LatticeNode node = createNode();
+    LatticeNodeImpl getOOVNode(String text, OOV oov, int length) {
+        LatticeNodeImpl node = createNode();
         node.setParameter(oov.leftId, oov.rightId, oov.cost);
         WordInfo info = new WordInfo(text, (short) length, oov.posId, text, text, "");
         node.setWordInfo(info);
@@ -133,8 +135,11 @@ class MeCabOovProviderPlugin extends OovProviderPlugin {
     private static final Pattern PATTERN_SPACES = Pattern.compile("\\s+");
     private static final Pattern PATTERN_EMPTY_OR_SPACES = Pattern.compile("\\s*");
 
-    void readCharacterProperty(String charDef) throws IOException {
-        try (InputStream input = (charDef == null) ? openFromJar("char.def") : new FileInputStream(charDef);
+    <T> void readCharacterProperty(Config.Resource<T> charDef) throws IOException {
+        if (charDef == null) {
+            charDef = settings.getResource("char.def");
+        }
+        try (InputStream input = charDef.asInputStream();
                 InputStreamReader isReader = new InputStreamReader(input, StandardCharsets.UTF_8);
                 LineNumberReader reader = new LineNumberReader(isReader)) {
             for (String line = reader.readLine(); line != null; line = reader.readLine()) {
@@ -166,8 +171,11 @@ class MeCabOovProviderPlugin extends OovProviderPlugin {
         }
     }
 
-    void readOOV(String unkDef, Grammar grammar) throws IOException {
-        try (InputStream input = (unkDef == null) ? openFromJar("unk.def") : new FileInputStream(unkDef);
+    <T> void readOOV(Config.Resource<T> unkDef, Grammar grammar) throws IOException {
+        if (unkDef == null) {
+            unkDef = settings.getResource("unk.def");
+        }
+        try (InputStream input = unkDef.asInputStream();
                 InputStreamReader isReader = new InputStreamReader(input, StandardCharsets.UTF_8);
                 LineNumberReader reader = new LineNumberReader(isReader)) {
             for (String line = reader.readLine(); line != null; line = reader.readLine()) {
@@ -193,12 +201,8 @@ class MeCabOovProviderPlugin extends OovProviderPlugin {
                 List<String> pos = Arrays.asList(cols[4], cols[5], cols[6], cols[7], cols[8], cols[9]);
                 oov.posId = grammar.getPartOfSpeechId(pos);
 
-                oovList.computeIfAbsent(type, t -> new ArrayList<OOV>()).add(oov);
+                oovList.computeIfAbsent(type, t -> new ArrayList<>()).add(oov);
             }
         }
-    }
-
-    private InputStream openFromJar(String path) {
-        return MeCabOovProviderPlugin.class.getClassLoader().getResourceAsStream(path);
     }
 }

--- a/src/main/java/com/worksap/nlp/sudachi/MeCabOovProviderPlugin.java
+++ b/src/main/java/com/worksap/nlp/sudachi/MeCabOovProviderPlugin.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.regex.Pattern;
 
@@ -132,7 +133,7 @@ class MeCabOovProviderPlugin extends OovProviderPlugin {
 
     <T> void readCharacterProperty(Config.Resource<T> charDef) throws IOException {
         if (charDef == null) {
-            charDef = settings.getResource("char.def");
+            charDef = settings.base.toResource(Paths.get("char.def"));
         }
         try (InputStream input = charDef.asInputStream();
                 InputStreamReader isReader = new InputStreamReader(input, StandardCharsets.UTF_8);
@@ -168,7 +169,7 @@ class MeCabOovProviderPlugin extends OovProviderPlugin {
 
     <T> void readOOV(Config.Resource<T> unkDef, Grammar grammar) throws IOException {
         if (unkDef == null) {
-            unkDef = settings.getResource("unk.def");
+            unkDef = settings.base.toResource(Paths.get("unk.def"));
         }
         try (InputStream input = unkDef.asInputStream();
                 InputStreamReader isReader = new InputStreamReader(input, StandardCharsets.UTF_8);

--- a/src/main/java/com/worksap/nlp/sudachi/RegexOovProvider.java
+++ b/src/main/java/com/worksap/nlp/sudachi/RegexOovProvider.java
@@ -73,8 +73,6 @@ public class RegexOovProvider extends OovProviderPlugin {
         leftId = checkedShort(settings, "leftId");
         rightId = checkedShort(settings, "rightId");
         pattern = checkPattern(settings.getString("regex"));
-        // force compilation of the pattern here
-        pattern.matcher("test").reset();
     }
 
     @Override

--- a/src/main/java/com/worksap/nlp/sudachi/RegexOovProvider.java
+++ b/src/main/java/com/worksap/nlp/sudachi/RegexOovProvider.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2022 Works Applications Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.worksap.nlp.sudachi;
+
+import com.worksap.nlp.sudachi.dictionary.Grammar;
+import com.worksap.nlp.sudachi.dictionary.POS;
+import com.worksap.nlp.sudachi.dictionary.WordInfo;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Provides OOVs based on a regular expression. Does not produce OOVs if one
+ * with the same boundaries was already present in the dictionary or was
+ * produced by a previous OOV provider.
+ *
+ * <p>
+ * Configuration example:
+ * 
+ * <pre>
+ * {@code
+ *  {
+ *      "class": "com.worksap.nlp.sudachi.RegexOovProvider",
+ *      "regex": "[0-9a-z-]+",
+ *      "pos": [ "補助記号", "一般", "*", "*", "*", "*" ],
+ *      "leftId": 500,
+ *      "rightId": 500,
+ *      "cost": 5000
+ *  }
+ * }
+ * </pre>
+ *
+ * Recommendations on regular expressions:
+ * <ul>
+ * <li>Make regex as simple as possible, it will be evaluated many times</li>
+ * <li>Do not use capturing groups {@code (test)}, instead use non-capturing
+ * groups {@code (?:test)}</li>
+ * <li>Do not use lookahead and lookaround</li>
+ * </ul>
+ */
+public class RegexOovProvider extends OovProviderPlugin {
+    private Pattern pattern;
+    private short posId = -1;
+    private short cost = Short.MIN_VALUE;
+    private short leftId = Short.MIN_VALUE;
+    private short rightId = Short.MIN_VALUE;
+
+    @Override
+    public void setUp(Grammar grammar) throws IOException {
+        super.setUp(grammar);
+        POS stringPos = new POS(settings.getStringList("pos"));
+        posId = grammar.getPartOfSpeechId(stringPos);
+        if (posId == -1) {
+            throw new IllegalArgumentException("POS " + stringPos + " was not present in the dictionary");
+        }
+        cost = checkedShort(settings, "cost");
+        leftId = checkedShort(settings, "leftId");
+        rightId = checkedShort(settings, "rightId");
+        pattern = checkPattern(settings.getString("regex"));
+        // force compilation of the pattern here
+        pattern.matcher("test").reset();
+    }
+
+    @Override
+    public int provideOOV(InputText inputText, int offset, long otherWords, List<LatticeNodeImpl> nodes) {
+        String text = inputText.getText();
+        Matcher matcher = pattern.matcher(text);
+        byte[] byteText = inputText.getByteText();
+        int textLength = byteText.length;
+        int regionStartChars = inputText.modifiedOffset(offset);
+        int regionEndBytes = Math.min(offset + 64, textLength);
+        int regionEndChars = inputText.modifiedOffset(regionEndBytes);
+        matcher.region(regionStartChars, regionEndChars);
+
+        if (matcher.find()) {
+            int endChar = matcher.end();
+            int oovLength = inputText.getCodePointsOffsetLength(offset, endChar - regionStartChars);
+            if (WordMask.hasNth(otherWords, oovLength)) {
+                return 0;
+            }
+
+            LatticeNodeImpl node = new LatticeNodeImpl(null, leftId, rightId, cost, -1);
+            node.setOOV();
+            node.setRange(offset, matcher.end());
+            String oov = inputText.getSubstring(matcher.start(), matcher.end());
+            WordInfo info = new WordInfo(oov, (short) oovLength, posId, oov, oov, "");
+            node.setWordInfo(info);
+            nodes.add(node);
+            return 1;
+        } else {
+            return 0;
+        }
+    }
+
+    private static short checkedShort(Settings settings, String name) {
+        int value = settings.getInt(name);
+        if (value > Short.MAX_VALUE) {
+            throw new IllegalArgumentException(
+                    "The value of parameter " + name + " was larger than " + Short.MAX_VALUE);
+        }
+        return (short) value;
+    }
+
+    private static Pattern checkPattern(String regex) {
+        // prepend begin of sequence for fast non-matching case
+        if (!regex.startsWith("^")) {
+            regex = "^" + regex;
+        }
+        Pattern pattern = Pattern.compile(regex);
+        // force compilation of the pattern here no matter the situation
+        Matcher x = pattern.matcher("does not matter");
+        x.reset();
+        return pattern;
+    }
+}

--- a/src/main/java/com/worksap/nlp/sudachi/RegexOovProvider.java
+++ b/src/main/java/com/worksap/nlp/sudachi/RegexOovProvider.java
@@ -97,8 +97,7 @@ public class RegexOovProvider extends OovProviderPlugin {
 
             LatticeNodeImpl node = new LatticeNodeImpl(null, leftId, rightId, cost, -1);
             node.setOOV();
-            node.setRange(offset, matcher.end());
-            String oov = inputText.getSubstring(matcher.start(), matcher.end());
+            String oov = text.substring(matcher.start(), matcher.end());
             WordInfo info = new WordInfo(oov, (short) oovLength, posId, oov, oov, "");
             node.setWordInfo(info);
             nodes.add(node);

--- a/src/main/java/com/worksap/nlp/sudachi/Settings.java
+++ b/src/main/java/com/worksap/nlp/sudachi/Settings.java
@@ -171,6 +171,7 @@ public class Settings {
     @Deprecated
     public static Settings parseSettings(String path, String json) {
         SettingsAnchor anchor = path == null ? SettingsAnchor.none() : SettingsAnchor.filesystem(Paths.get(path));
+        anchor = anchor.andThen(SettingsAnchor.classpath());
         return parse(json, anchor);
     }
 

--- a/src/main/java/com/worksap/nlp/sudachi/SimpleOovProviderPlugin.java
+++ b/src/main/java/com/worksap/nlp/sudachi/SimpleOovProviderPlugin.java
@@ -16,14 +16,15 @@
 
 package com.worksap.nlp.sudachi;
 
-import java.util.Collections;
-import java.util.List;
-
 import com.worksap.nlp.sudachi.dictionary.Grammar;
 import com.worksap.nlp.sudachi.dictionary.WordInfo;
 
+import java.util.List;
+
 /**
- * Provides the OOVs.
+ * Provides the OOVs which consists of a maximum run of characters of a single
+ * character class. Does not produce OOVs if there was any other word at the
+ * boundary.
  *
  * <p>
  * The following is an example of settings.
@@ -68,17 +69,18 @@ class SimpleOovProviderPlugin extends OovProviderPlugin {
     }
 
     @Override
-    public List<LatticeNode> provideOOV(InputText inputText, int offset, boolean hasOtherWords) {
-        if (!hasOtherWords) {
-            LatticeNode node = createNode();
+    public int provideOOV(InputText inputText, int offset, long otherWords, List<LatticeNodeImpl> nodes) {
+        if (otherWords == 0) {
+            LatticeNodeImpl node = createNode();
             node.setParameter(leftId, rightId, cost);
             int length = inputText.getWordCandidateLength(offset);
             String s = inputText.getSubstring(offset, offset + length);
             WordInfo info = new WordInfo(s, (short) length, oovPOSId, s, s, "");
             node.setWordInfo(info);
-            return Collections.singletonList(node);
+            nodes.add(node);
+            return 1;
         } else {
-            return Collections.emptyList();
+            return 0;
         }
     }
 }

--- a/src/main/java/com/worksap/nlp/sudachi/SudachiCommandLine.java
+++ b/src/main/java/com/worksap/nlp/sudachi/SudachiCommandLine.java
@@ -210,7 +210,7 @@ public class SudachiCommandLine {
         for (i = 0; i < args.length; i++) {
             if (args[i].equals("-r") && i + 1 < args.length) {
                 Path configPath = Paths.get(args[++i]);
-                anchor = SettingsAnchor.filesystem(configPath.getParent());
+                anchor = SettingsAnchor.filesystem(configPath.getParent()).andThen(SettingsAnchor.classpath());
                 current = Settings.fromFile(configPath, anchor);
             } else if (args[i].equals("-p") && i + 1 < args.length) {
                 String resourcesDirectory = args[++i];

--- a/src/main/java/com/worksap/nlp/sudachi/UTF8InputText.java
+++ b/src/main/java/com/worksap/nlp/sudachi/UTF8InputText.java
@@ -63,7 +63,7 @@ class UTF8InputText implements InputText {
         return modifiedText;
     }
 
-    byte[] getByteText() {
+    public byte[] getByteText() {
         return bytes;
     }
 
@@ -132,7 +132,7 @@ class UTF8InputText implements InputText {
                 modifiedToOriginal, charCategories, charCategoryContinuities, canBowList);
     }
 
-    int getOffsetTextLength(int index) {
+    public int modifiedOffset(int index) {
         return byteToModified[index];
     }
 

--- a/src/main/java/com/worksap/nlp/sudachi/WordMask.java
+++ b/src/main/java/com/worksap/nlp/sudachi/WordMask.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022 Works Applications Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.worksap.nlp.sudachi;
+
+public class WordMask {
+    /**
+     * Add n-th element to wordMask
+     * 
+     * @param positions
+     *            current mask of word positions
+     * @param position
+     *            new position to add
+     * @return position mask with the new element added
+     */
+    public static long addNth(long positions, int position) {
+        return positions | nth(position);
+    }
+
+    /**
+     * Create a word mask with nth position set
+     * 
+     * @param position
+     *            number of set position
+     * @return a word mask bitset
+     */
+    public static long nth(int position) {
+        assert position > 0;
+        int fixedPosition = Math.min(position - 1, 63);
+        return 1L << fixedPosition;
+    }
+
+    /**
+     * Checks that a word mask has nth position set
+     * 
+     * @param positions
+     *            word mask of positions
+     * @param position
+     *            position to check
+     * @return whether the checked position was included in the set
+     */
+    public static boolean hasNth(long positions, int position) {
+        return (positions & nth(position)) != 0;
+    }
+}

--- a/src/main/java/com/worksap/nlp/sudachi/WordMask.java
+++ b/src/main/java/com/worksap/nlp/sudachi/WordMask.java
@@ -17,6 +17,12 @@
 package com.worksap.nlp.sudachi;
 
 public class WordMask {
+
+    // instance creation is forbidden
+    private WordMask() {
+
+    }
+
     /**
      * Add n-th element to wordMask
      * 

--- a/src/main/java/com/worksap/nlp/sudachi/dictionary/POS.java
+++ b/src/main/java/com/worksap/nlp/sudachi/dictionary/POS.java
@@ -18,6 +18,7 @@ package com.worksap.nlp.sudachi.dictionary;
 
 import java.util.AbstractList;
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * Part-of-Speech
@@ -52,6 +53,16 @@ public final class POS extends AbstractList<String> {
             }
         }
         this.elems = elems;
+    }
+
+    /**
+     * Creates new POS instance from
+     * 
+     * @param elems
+     * @return
+     */
+    public POS(List<String> elems) {
+        this(elems.toArray(new String[0]));
     }
 
     @Override

--- a/src/test/java/com/worksap/nlp/sudachi/JapaneseTokenizerMaskTest.kt
+++ b/src/test/java/com/worksap/nlp/sudachi/JapaneseTokenizerMaskTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2022 Works Applications Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.worksap.nlp.sudachi
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class JapaneseTokenizerMaskTest {
+  private class CaptureOtherWords : OovProviderPlugin() {
+    val otherWords = ArrayList<Pair<Int, Long>>()
+    override fun provideOOV(
+        inputText: InputText?,
+        offset: Int,
+        otherWords: Long,
+        result: MutableList<LatticeNodeImpl>?
+    ): Int {
+      this.otherWords.add(offset to otherWords)
+      return 0
+    }
+  }
+
+  @Test
+  fun correctMasksWithFirstProvider() {
+    val cfg0 = Config.empty()
+    cfg0.addOovProviderPlugin(CaptureOtherWords::class.java)
+    val cfg = cfg0.merge(TestDictionary.user0Cfg(), Config.MergeMode.APPEND)
+    val dic = DictionaryFactory().create(cfg) as JapaneseDictionary
+    val tokenizer = dic.create()
+
+    assertIs<CaptureOtherWords>(dic.oovProviderPlugins[0])
+    assertIs<SimpleOovProviderPlugin>(dic.oovProviderPlugins[1])
+
+    tokenizer.tokenize("かaiueoか")
+    val provider = dic.oovProviderPlugins.first { it is CaptureOtherWords } as CaptureOtherWords
+    val otherWords = provider.otherWords
+    assertEquals(3, otherWords.size)
+    // in this order word masks are empty
+    assertEquals(0 to 0L, otherWords[0])
+    assertEquals(3 to 0L, otherWords[1])
+    assertEquals(8 to 0L, otherWords[2])
+  }
+
+  @Test
+  fun correctMasksWithSecondProvider() {
+    val cfg = TestDictionary.user0Cfg()
+    cfg.addOovProviderPlugin(CaptureOtherWords::class.java)
+    val dic = DictionaryFactory().create(cfg) as JapaneseDictionary
+    val tokenizer = dic.create()
+
+    assertIs<SimpleOovProviderPlugin>(dic.oovProviderPlugins[0])
+    assertIs<CaptureOtherWords>(dic.oovProviderPlugins[1])
+
+    tokenizer.tokenize("かaiueoか")
+    val provider = dic.oovProviderPlugins.first { it is CaptureOtherWords } as CaptureOtherWords
+    val otherWords = provider.otherWords
+    assertEquals(3, otherWords.size)
+    // in this order word masks are not empty
+    assertEquals(0 to WordMask.nth(3), otherWords[0])
+    assertEquals(3 to WordMask.nth(5), otherWords[1])
+    assertEquals(8 to WordMask.nth(3), otherWords[2])
+  }
+}

--- a/src/test/java/com/worksap/nlp/sudachi/MeCabOovProviderPluginTest.java
+++ b/src/test/java/com/worksap/nlp/sudachi/MeCabOovProviderPluginTest.java
@@ -16,25 +16,26 @@
 
 package com.worksap.nlp.sudachi;
 
+import com.worksap.nlp.sudachi.MeCabOovProviderPlugin.CategoryInfo;
+import com.worksap.nlp.sudachi.dictionary.CategoryType;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-
-import java.io.*;
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-import java.util.*;
-import java.util.stream.Collectors;
-
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-
-import com.worksap.nlp.sudachi.MeCabOovProviderPlugin.CategoryInfo;
-import com.worksap.nlp.sudachi.dictionary.CategoryType;
 
 public class MeCabOovProviderPluginTest {
 

--- a/src/test/java/com/worksap/nlp/sudachi/MeCabOovProviderPluginTest.java
+++ b/src/test/java/com/worksap/nlp/sudachi/MeCabOovProviderPluginTest.java
@@ -28,6 +28,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -46,9 +47,6 @@ public class MeCabOovProviderPluginTest {
             return (List<LatticeNode>) nodes;
         }
     }
-
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     TestPlugin plugin;
     MockInputText inputText;
@@ -177,6 +175,8 @@ public class MeCabOovProviderPluginTest {
         assertThat(nodes.size(), is(0));
     }
 
+    @Test
+    @Ignore
     public void provideOOV102() {
         MeCabOovProviderPlugin.CategoryInfo cinfo = new MeCabOovProviderPlugin.CategoryInfo();
         cinfo.type = CategoryType.KANJI;

--- a/src/test/java/com/worksap/nlp/sudachi/MockInputText.java
+++ b/src/test/java/com/worksap/nlp/sudachi/MockInputText.java
@@ -118,4 +118,14 @@ class MockInputText implements InputText {
     public int getNextInOriginal(int index) {
         return index + 1;
     }
+
+    @Override
+    public int modifiedOffset(int index) {
+        return 0;
+    }
+
+    @Override
+    public byte[] getByteText() {
+        return new byte[0];
+    }
 }

--- a/src/test/java/com/worksap/nlp/sudachi/RegexOovProviderTest.kt
+++ b/src/test/java/com/worksap/nlp/sudachi/RegexOovProviderTest.kt
@@ -57,4 +57,12 @@ class RegexOovProviderTest {
     assertEquals("xag-2f", tokens[2].normalizedForm())
     assertEquals("", tokens[2].readingForm())
   }
+
+  @Test
+  fun singleMultibyte() {
+    val tokens = analyzer.tokenize("２つＧ")
+    assertEquals(3, tokens.size)
+    assertEquals("Ｇ", tokens[2].surface())
+    assertEquals("g", tokens[2].normalizedForm())
+  }
 }

--- a/src/test/java/com/worksap/nlp/sudachi/RegexOovProviderTest.kt
+++ b/src/test/java/com/worksap/nlp/sudachi/RegexOovProviderTest.kt
@@ -51,8 +51,10 @@ class RegexOovProviderTest {
 
   @Test
   fun hasOtherConflictingWords() {
-    val tokens = analyzer.tokenize("2つXAG-2F")
+    val tokens = analyzer.tokenize("２つXＡＧ-2F")
     assertEquals(3, tokens.size)
-    assertEquals("XAG-2F", tokens[2].surface())
+    assertEquals("XＡＧ-2F", tokens[2].surface())
+    assertEquals("xag-2f", tokens[2].normalizedForm())
+    assertEquals("", tokens[2].readingForm())
   }
 }

--- a/src/test/java/com/worksap/nlp/sudachi/RegexOovProviderTest.kt
+++ b/src/test/java/com/worksap/nlp/sudachi/RegexOovProviderTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022 Works Applications Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.worksap.nlp.sudachi
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RegexOovProviderTest {
+  private val analyzer =
+      kotlin.run {
+        val cfg = Config.empty()
+        cfg.addOovProviderPlugin(RegexOovProvider::class.java)
+            .add("regex", """[0-9a-z-]+""")
+            .add("cost", 3500)
+            .add("leftId", 5)
+            .add("rightId", 5)
+            .addList("pos", "名詞", "普通名詞", "一般", "*", "*", "*")
+        // prepend our OOV configuration to the main configuration
+        DictionaryFactory()
+            .create(cfg.merge(TestDictionary.user0Cfg(), Config.MergeMode.APPEND))
+            .create()
+      }
+
+  @Test
+  fun noOtherWords() {
+    val tokens = analyzer.tokenize("XAG-2F")
+    assertEquals(1, tokens.size)
+    assertEquals("XAG-2F", tokens[0].surface())
+  }
+
+  @Test
+  fun hasOtherWords() {
+    val tokens = analyzer.tokenize("京都XAG-2F東京")
+    assertEquals(3, tokens.size)
+    assertEquals("XAG-2F", tokens[1].surface())
+  }
+
+  @Test
+  fun hasOtherConflictingWords() {
+    val tokens = analyzer.tokenize("2つXAG-2F")
+    assertEquals(3, tokens.size)
+    assertEquals("XAG-2F", tokens[2].surface())
+  }
+}

--- a/src/test/java/com/worksap/nlp/sudachi/UTF8InputTextTest.java
+++ b/src/test/java/com/worksap/nlp/sudachi/UTF8InputTextTest.java
@@ -284,9 +284,9 @@ public class UTF8InputTextTest {
         input = input.slice(1, 3);
         assertThat(input.getOriginalText(), is("ｂC1"));
         assertThat(input.getText(), is("あ1"));
-        assertThat(input.getOffsetTextLength(1), is(0));
-        assertThat(input.getOffsetTextLength(3), is(1));
-        assertThat(input.getOffsetTextLength(4), is(2));
+        assertThat(input.modifiedOffset(1), is(0));
+        assertThat(input.modifiedOffset(3), is(1));
+        assertThat(input.modifiedOffset(4), is(2));
         assertThat(input.getOriginalIndex(3), is(2));
         assertThat(input.getOriginalIndex(4), is(3));
     }

--- a/src/test/java/com/worksap/nlp/sudachi/WordMaskTest.kt
+++ b/src/test/java/com/worksap/nlp/sudachi/WordMaskTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022 Works Applications Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.worksap.nlp.sudachi
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class WordMaskTest {
+
+  @Test
+  fun works() {
+    (1..65).forEach { i ->
+      val mask = WordMask.nth(i)
+      assertTrue(WordMask.hasNth(mask, i))
+    }
+  }
+
+  @Test
+  fun addNth() {
+    val mask1 = WordMask.addNth(0, 1)
+    val mask2 = WordMask.addNth(mask1, 3)
+    val mask3 = WordMask.addNth(mask2, 64)
+    assertTrue(WordMask.hasNth(mask3, 1))
+    assertFalse(WordMask.hasNth(mask3, 2))
+    assertTrue(WordMask.hasNth(mask3, 3))
+    assertFalse(WordMask.hasNth(mask3, 4))
+    assertFalse(WordMask.hasNth(mask3, 63))
+    assertTrue(WordMask.hasNth(mask3, 64))
+    assertTrue(WordMask.hasNth(mask3, 65))
+  }
+}

--- a/src/test/java/com/worksap/nlp/sudachi/dictionary/build/SystemDicTest.kt
+++ b/src/test/java/com/worksap/nlp/sudachi/dictionary/build/SystemDicTest.kt
@@ -38,7 +38,8 @@ class SystemDicTest {
     val bldr = DicBuilder.system().matrix(javaClass.getResource("test.matrix"))
     val data = MemChannel()
     repeat(10) { bldr.lexicon(javaClass.getResource("one.csv")) }
-    bldr.lexicon("南,1,1,4675,南,名詞,普通名詞,一般,*,*,*,ミナミ,西,5,C,0/1,2/3,4/5,6/7".byteInputStream())
+    bldr
+        .lexicon("南,1,1,4675,南,名詞,普通名詞,一般,*,*,*,ミナミ,西,5,C,0/1,2/3,4/5,6/7".byteInputStream())
         .build(data)
     val dic = BinaryDictionary(data.buffer())
     assertEquals(11, dic.lexicon.size())
@@ -88,7 +89,8 @@ class SystemDicTest {
   fun aSplits() {
     val bldr = DicBuilder.system().matrix(res("test.matrix"))
     val data = MemChannel()
-    bldr.lexicon(
+    bldr
+        .lexicon(
             """東京,1,1,2816,東京,名詞,固有名詞,地名,一般,*,*,トウキョウ,東京,*,A,*,*,*,*
                         東京都,2,2,5320,東京都,名詞,固有名詞,地名,一般,*,*,トウキョウト,東京都,*,B,0/2,*,0/2,*
                         都,2,2,2914,都,名詞,普通名詞,一般,*,*,*,ト,都,*,A,*,*,*,*"""
@@ -106,7 +108,8 @@ class SystemDicTest {
   fun aSplitsInline() {
     val bldr = DicBuilder.system().matrix(res("test.matrix"))
     val data = MemChannel()
-    bldr.lexicon(
+    bldr
+        .lexicon(
             """東京,1,1,2816,東京,名詞,固有名詞,地名,一般,*,*,トウキョウ,東京,*,A,*,*,*,*
                         東京都,2,2,5320,東京都,名詞,固有名詞,地名,一般,*,*,トウキョウト,東京都,*,B,"東京,名詞,固有名詞,地名,一般,*,*,トウキョウ/2",*,0/2,*
                         都,2,2,2914,都,名詞,普通名詞,一般,*,*,*,ト,都,*,A,*,*,*,*"""
@@ -124,7 +127,8 @@ class SystemDicTest {
   fun bSplits() {
     val bldr = DicBuilder.system().matrix(res("test.matrix"))
     val data = MemChannel()
-    bldr.lexicon(
+    bldr
+        .lexicon(
             """東京,1,1,2816,東京,名詞,固有名詞,地名,一般,*,*,トウキョウ,東京,*,A,*,*,*,*
                         東京都,2,2,5320,東京都,名詞,固有名詞,地名,一般,*,*,トウキョウト,東京都,*,B,*,0/2,0/2,*
                         都,2,2,2914,都,名詞,普通名詞,一般,*,*,*,ト,都,*,A,*,*,*,*"""
@@ -142,7 +146,8 @@ class SystemDicTest {
   fun systemSplitU() {
     val bldr = DicBuilder.system().matrix(res("test.matrix"))
     val data = MemChannel()
-    bldr.lexicon(
+    bldr
+        .lexicon(
             """東京,1,1,2816,東京,名詞,固有名詞,地名,一般,*,*,トウキョウ,東京,*,A,*,*,*,*
                         東京都,2,2,5320,東京都,名詞,固有名詞,地名,一般,*,*,トウキョウト,東京都,*,B,*,0/2,U0/U2,*
                         都,2,2,2914,都,名詞,普通名詞,一般,*,*,*,ト,都,*,A,*,*,*,*"""


### PR DESCRIPTION
1. Analysis now tracks length of created words with a 64-bit bitfield instead of only flags whether a word was created at a bounary
2. OOV plugins can access all other created words at this point for the boundary
3. Add a Regex-based OOV plugin which creates OOVs based on a regular expression-based rule.