### PR TITLE
fix incorrect size calculation when expand

### DIFF
--- a/src/main/java/com/worksap/nlp/sudachi/LatticeImpl.java
+++ b/src/main/java/com/worksap/nlp/sudachi/LatticeImpl.java
@@ -77,7 +77,7 @@ class LatticeImpl implements Lattice {
 
     void expand(int newSize) {
         endLists.ensureCapacity(newSize + 1);
-        for (int i = size + 1; i < newSize + 1; i++) {
+        for (int i = capacity + 1; i < newSize + 1; i++) {
             endLists.add(new ArrayList<>());
         }
         capacity = newSize;


### PR DESCRIPTION
sizeはclear時に毎回0になるため、expand時に本来必要なサイズより多くArrayListオブジェクトを作成してしまいます。