### PR TITLE
Mention about output format in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ $ java -jar sudachi-XX.jar [-r conf] [-s json] [-m mode] [-a] [-d] [-f] [-o outp
     $ echo 東京都へ行く | java -jar target/sudachi.jar -t
     東京都 へ 行く
 
+Check [the simple formatter](./src/main/java/com/worksap/nlp/sudachi/SimpleMorphemeFormatter.java) for the output format.
+
 ## How to use the API
 
 You can find details in the Javadoc.
@@ -437,6 +439,7 @@ $ java -jar sudachi-XX.jar [-r conf] [-s json] [-m mode] [-a] [-d] [-f] [-o outp
     $ echo 東京都へ行く | java -jar target/sudachi.jar -t
     東京都 へ 行く
 
+出力フォーマットについては、[シンプルフォーマッタ](./src/main/java/com/worksap/nlp/sudachi/SimpleMorphemeFormatter.java)を確認してください。
 
 ## ライブラリの利用
 


### PR DESCRIPTION
Hello there,
I tried Sudachi with `-a`; the problem is that the output has a weird number at the end for some inputs.

Like this:
~~~
開き	動詞,一般,*,*,五段-カ行,連用形-一般	開く	開く	ヒラキ	0	[22589]
~~~

It would be better if you mentioned something to help out new users in the README. Especially for users who are just Japanese learners.

I understand it is complicated with option flags and plugins. However, there should be a link to the relevant code so that people can understand it better.