### PR TITLE
Set `ByteOrder.LITTLE_ENDIAN` for ByteBuffer from `Config.Resource.asByteBuffer`

### DIFF
--- a/src/main/java/com/worksap/nlp/sudachi/Config.java
+++ b/src/main/java/com/worksap/nlp/sudachi/Config.java
@@ -960,7 +960,7 @@ public class Config {
                 if (Objects.equals(url.getProtocol(), "file")) {
                     return MMap.map(url.getPath());
                 }
-                return StringUtil.readAllBytes(url, ByteOrder.LITTLE_ENDIAN);
+                return StringUtil.readAllBytes(url);
             }
 
             @Override

--- a/src/main/java/com/worksap/nlp/sudachi/Config.java
+++ b/src/main/java/com/worksap/nlp/sudachi/Config.java
@@ -29,6 +29,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
@@ -866,7 +867,8 @@ public class Config {
         /**
          * Get view of this resource as a ByteBuffer. When it is possible, the data will
          * be memory mapped, if it is not possible, it will be fully read into the
-         * memory. Will not work for files more than 2^31 bytes (2 GB) in size.
+         * memory. Will not work for files more than 2^31 bytes (2 GB) in size. The
+         * ByteOrder is set to little endian.
          *
          * @return ByteBuffer containing the whole contents of the file
          * @throws IOException
@@ -958,7 +960,7 @@ public class Config {
                 if (Objects.equals(url.getProtocol(), "file")) {
                     return MMap.map(url.getPath());
                 }
-                return StringUtil.readAllBytes(url);
+                return StringUtil.readAllBytes(url, ByteOrder.LITTLE_ENDIAN);
             }
 
             @Override

--- a/src/main/java/com/worksap/nlp/sudachi/StringUtil.java
+++ b/src/main/java/com/worksap/nlp/sudachi/StringUtil.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -56,12 +57,20 @@ public class StringUtil {
     }
 
     public static ByteBuffer readAllBytes(URL url) throws IOException {
+        return readAllBytes(url, ByteOrder.BIG_ENDIAN);
+    }
+
+    public static ByteBuffer readAllBytes(URL url, ByteOrder order) throws IOException {
         try (InputStream is = url.openStream()) {
-            return readAllBytes(is);
+            return readAllBytes(is, order);
         }
     }
 
     public static ByteBuffer readAllBytes(InputStream inputStream) throws IOException {
+        return readAllBytes(inputStream, ByteOrder.BIG_ENDIAN);
+    }
+
+    public static ByteBuffer readAllBytes(InputStream inputStream, ByteOrder order) throws IOException {
         byte[] buffer = new byte[inputStream.available() + 1024];
         int offset = 0;
 
@@ -78,6 +87,7 @@ public class StringUtil {
         }
         ByteBuffer bbuf = ByteBuffer.wrap(buffer);
         bbuf.limit(offset);
+        bbuf.order(order);
         return bbuf;
     }
 }

--- a/src/main/java/com/worksap/nlp/sudachi/StringUtil.java
+++ b/src/main/java/com/worksap/nlp/sudachi/StringUtil.java
@@ -57,7 +57,7 @@ public class StringUtil {
     }
 
     public static ByteBuffer readAllBytes(URL url) throws IOException {
-        return readAllBytes(url, ByteOrder.BIG_ENDIAN);
+        return readAllBytes(url, ByteOrder.LITTLE_ENDIAN);
     }
 
     public static ByteBuffer readAllBytes(URL url, ByteOrder order) throws IOException {
@@ -67,7 +67,7 @@ public class StringUtil {
     }
 
     public static ByteBuffer readAllBytes(InputStream inputStream) throws IOException {
-        return readAllBytes(inputStream, ByteOrder.BIG_ENDIAN);
+        return readAllBytes(inputStream, ByteOrder.LITTLE_ENDIAN);
     }
 
     public static ByteBuffer readAllBytes(InputStream inputStream, ByteOrder order) throws IOException {


### PR DESCRIPTION
fix #238.

Add `ByteBuffer order` argument to `StringUtil.readAllBytes` and use it to set `ByteOrder.LITTLE_ENDIAN` for ByteBuffer from `Config.Resource.asByteBuffer`.