### PR TITLE
Create TextNormalizer from dictionary

### DIFF
--- a/src/main/java/com/worksap/nlp/sudachi/Dictionary.java
+++ b/src/main/java/com/worksap/nlp/sudachi/Dictionary.java
@@ -112,4 +112,12 @@ public interface Dictionary extends AutoCloseable {
     default PosMatcher posMatcher(PartialPOS... posList) {
         return posMatcher(Arrays.asList(posList));
     }
+
+    /**
+     * Create a TextNormalizer that works based on the grammar and InputTextPlugins
+     * of this dictionary
+     * 
+     * @return TextNormalizer based on this dictionary.
+     */
+    TextNormalizer textNormalizer();
 }

--- a/src/main/java/com/worksap/nlp/sudachi/JapaneseDictionary.java
+++ b/src/main/java/com/worksap/nlp/sudachi/JapaneseDictionary.java
@@ -181,4 +181,9 @@ public class JapaneseDictionary implements Dictionary, DictionaryAccess {
                 .toArray();
         return new PosMatcher(ids, this);
     }
+
+    @Override
+    public TextNormalizer textNormalizer() {
+        return new TextNormalizer(grammar, inputTextPlugins);
+    }
 }

--- a/src/main/java/com/worksap/nlp/sudachi/TextNormalizer.java
+++ b/src/main/java/com/worksap/nlp/sudachi/TextNormalizer.java
@@ -69,7 +69,10 @@ public class TextNormalizer {
 
     /**
      * Create TextNormalizer based on the {@link JapaneseDictionary}.
+     * 
+     * @deprecated use Dictionary.textNormalizer() instead
      */
+    @Deprecated
     public static TextNormalizer fromDictionary(JapaneseDictionary dictionary) {
         return new TextNormalizer(dictionary.getGrammar(), dictionary.inputTextPlugins);
     }

--- a/src/test/java/com/worksap/nlp/sudachi/TextNormalizerTest.kt
+++ b/src/test/java/com/worksap/nlp/sudachi/TextNormalizerTest.kt
@@ -29,7 +29,7 @@ class TextNormalizerTest {
 
   @Test
   fun instantiation() {
-    TextNormalizer.fromDictionary(dic)
+    dic.textNormalizer()
     TextNormalizer(dic.getGrammar())
     TextNormalizer(dic.getGrammar(), dic.inputTextPlugins)
     TextNormalizer.defaultTextNormalizer()
@@ -53,7 +53,7 @@ class TextNormalizerTest {
   fun normalizeTextWithDefaultConfig() {
     // will use default config, which has InputTextPlugins of
     // [Default, ProlongedSoundMark, IgnoreYomigana]
-    val tn = TextNormalizer.fromDictionary(dic)
+    val tn = dic.textNormalizer()
     print(dic.inputTextPlugins)
 
     assertEquals("âbγд(株)ガヴ⼼ⅲ", tn.normalize("ÂＢΓД㈱ｶﾞウ゛⼼Ⅲ")) // default


### PR DESCRIPTION
Change the way to create `TextNormalizer` based on a `Dictionary` from `TextNormalizer.fromDictionary` to `Dictionary.textNormalizer`, aligning to other analyzers.

