### PR TITLE
remove unnecessary delimiter

### DIFF
--- a/src/main/java/com/worksap/nlp/sudachi/SimpleMorphemeFormatter.java
+++ b/src/main/java/com/worksap/nlp/sudachi/SimpleMorphemeFormatter.java
@@ -57,8 +57,10 @@ public class SimpleMorphemeFormatter extends MorphemeFormatterPlugin {
         if (showDetails) {
             output += columnDelimiter + morpheme.dictionaryForm() + columnDelimiter + morpheme.readingForm()
                     + columnDelimiter + morpheme.getDictionaryId() + columnDelimiter
-                    + Arrays.toString(morpheme.getSynonymGroupIds()) + columnDelimiter
-                    + ((morpheme.isOOV()) ? "(OOV)" : "");
+                    + Arrays.toString(morpheme.getSynonymGroupIds());
+            if (morpheme.isOOV()) {
+                output += columnDelimiter + "(OOV)";
+            }
         }
         return output;
     }

--- a/src/test/java/com/worksap/nlp/sudachi/SudachiCommandLineTest.java
+++ b/src/test/java/com/worksap/nlp/sudachi/SudachiCommandLineTest.java
@@ -125,6 +125,9 @@ public class SudachiCommandLineTest {
             assertTrue(first.isPresent());
             assertThat(first.get().split("\\t").length, is(7));
         }
+        try (Stream<String> lines = Files.lines(Paths.get(outputFileName))) {
+            assertThat(lines.filter(l -> !l.equals("EOS")).allMatch(l -> !l.endsWith("\t")), is(true));
+        }
     }
 
     @Test


### PR DESCRIPTION
Remove trailing `\t` (written when `-a` is set and the word is not OOV)