### PR TITLE
Dictionary-form wordref should not be converted to self-ref

### DIFF
--- a/src/main/java/com/worksap/nlp/sudachi/dictionary/build/RawLexiconReader.java
+++ b/src/main/java/com/worksap/nlp/sudachi/dictionary/build/RawLexiconReader.java
@@ -230,14 +230,21 @@ public class RawLexiconReader {
         return result;
     }
 
-    /** parse specified column as WordRef, also checks self-reference. */
-    private WordRef getWordRef(List<String> data, Column column, WordRef.Parser refParser, RawWordEntry entry) {
+    /**
+     * parse specified column as WordRef, also checks self-reference if requested.
+     */
+    private WordRef getWordRef(List<String> data, Column column, WordRef.Parser refParser, RawWordEntry entry,
+            boolean resolveSelfReferenceToNull) {
         String value = get(data, column, false);
         WordRef ref;
         try {
             ref = refParser.parse(value);
         } catch (IllegalArgumentException e) {
             throw new InputFileException(parser.getName(), parser.getRowCount(), column.name(), e);
+        }
+
+        if (!resolveSelfReferenceToNull) {
+            return ref;
         }
 
         // if parsed ref seems to refering current entry, return self-reference (null),
@@ -306,8 +313,8 @@ public class RawLexiconReader {
         entry.posId = getPos(data);
 
         // headword, pos, reading must be parsed before these to resolve wordref.
-        entry.normalizedFormRef = getWordRef(data, Column.NORMALIZED_FORM, normRefParser, entry);
-        entry.dictionaryFormRef = getWordRef(data, Column.DICTIONARY_FORM, dictRefParser, entry);
+        entry.normalizedFormRef = getWordRef(data, Column.NORMALIZED_FORM, normRefParser, entry, true);
+        entry.dictionaryFormRef = getWordRef(data, Column.DICTIONARY_FORM, dictRefParser, entry, false);
 
         entry.mode = get(data, Column.MODE, false);
         entry.aUnitSplit = getWordRefs(data, Column.SPLIT_A, splitParser);

--- a/src/test/java/com/worksap/nlp/sudachi/dictionary/build/RawLexiconReaderTest.kt
+++ b/src/test/java/com/worksap/nlp/sudachi/dictionary/build/RawLexiconReaderTest.kt
@@ -138,6 +138,23 @@ abc,0,0,1000,AbC,0,トウキョウト,,,,,"""
   }
 
   @Test
+  fun dictionaryFormKeepsExplicitReferenceToEarlierMatchingEntry() {
+    val text =
+        """IndexForm,LeftId,RightId,Cost,headword,pos_id,reading_form,normalized_form,DictionaryForm,splita,splitb,wordstructure
+base,0,0,1000,同形,0,ドウケイ,,,,,
+derived,0,0,1000,同形,0,ドウケイ,,"同形,0,ドウケイ",,,"""
+    val posTable = POSTable()
+    posTable.getId(POS("a", "a", "a", "a", "a", "0"))
+
+    val reader = RawLexiconReader(csvtext(text), posTable)
+    assertNotNull(reader.nextEntry())
+    assertNotNull(reader.nextEntry()).let { e ->
+      assertEquals(WordRef.RefByTriple("同形", 0, "ドウケイ"), e.dictionaryFormRef)
+    }
+    assertNull(reader.nextEntry())
+  }
+
+  @Test
   fun failMissingRequiredEntry() {
     // pos1-6 are not required (because of posId), but must be used as a set
     val columns =


### PR DESCRIPTION
Current system lexicon may contains words that have same headword-pos-reading set.
And in that case their dictionary form points to the first entry, not itself.
To keep backward compatibility, skip converting triple-word-ref into self-ref for the dictionary form.
