### PR TITLE
#351: find minimum node based on cost

### DIFF
--- a/src/main/java/com/worksap/nlp/sudachi/Lattice.java
+++ b/src/main/java/com/worksap/nlp/sudachi/Lattice.java
@@ -17,6 +17,7 @@
 package com.worksap.nlp.sudachi;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * A graph structure used in the morphological analysis.
@@ -71,7 +72,7 @@ public interface Lattice {
      *            the index to after the last position in the input text
      * @return the node which start at {@code begin} and end at {@code end}
      */
-    public LatticeNodeImpl getMinimumNode(int begin, int end);
+    public Optional<LatticeNodeImpl> getMinimumNode(int begin, int end);
 
     /**
      * Insert the node at the specified index.

--- a/src/main/java/com/worksap/nlp/sudachi/LatticeImpl.java
+++ b/src/main/java/com/worksap/nlp/sudachi/LatticeImpl.java
@@ -94,15 +94,9 @@ class LatticeImpl implements Lattice {
     }
 
     @Override
-    public LatticeNodeImpl getMinimumNode(int begin, int end) {
-        ArrayList<LatticeNodeImpl> ends = endLists.get(end);
-        LatticeNodeImpl result = null;
-        for (LatticeNodeImpl node : ends) {
-            if (node.begin == begin && (result == null || result.totalCost >= node.cost)) {
-                result = node;
-            }
-        }
-        return result;
+    public Optional<LatticeNodeImpl> getMinimumNode(int begin, int end) {
+        return endLists.get(end).stream().filter(n -> (n.getBegin() == begin))
+                .min(Comparator.comparingInt(n -> n.cost));
     }
 
     @Override

--- a/src/main/java/com/worksap/nlp/sudachi/PathRewritePlugin.java
+++ b/src/main/java/com/worksap/nlp/sudachi/PathRewritePlugin.java
@@ -18,6 +18,7 @@ package com.worksap.nlp.sudachi;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import com.worksap.nlp.sudachi.dictionary.CategoryType;
@@ -155,8 +156,9 @@ public abstract class PathRewritePlugin extends Plugin {
         int b = path.get(begin).getBegin();
         int e = path.get(end - 1).getEnd();
 
-        LatticeNodeImpl node = lattice.getMinimumNode(b, e);
-        if (node != null) {
+        Optional<LatticeNodeImpl> n = lattice.getMinimumNode(b, e);
+        if (n.isPresent()) {
+            LatticeNodeImpl node = n.get();
             replaceNode(path, begin, end, node);
             return node;
         }
@@ -168,7 +170,7 @@ public abstract class PathRewritePlugin extends Plugin {
         }
 
         String s = surface.toString();
-        node = factory.make(b, e, s);
+        LatticeNodeImpl node = factory.make(b, e, s);
         replaceNode(path, begin, end, node);
         return node;
     }


### PR DESCRIPTION
fix #351 

fix comparison with different field: `result.totalCost >= node.cost`.
here we want to find node, so `totalCost`, which is the cost of the path from BOS, is not appropriate.
