### PR TITLE
Change PathAnchor behavior for elasticsearch-sudachi

### DIFF
--- a/src/main/java/com/worksap/nlp/sudachi/Config.java
+++ b/src/main/java/com/worksap/nlp/sudachi/Config.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2022 Works Applications Co., Ltd.
+ * Copyright (c) 2017-2026 Works Applications Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
@@ -242,7 +241,10 @@ public class Config {
      */
     public static <T> Config fromResource(Resource<T> resource, PathAnchor anchor) throws IOException {
         if (resource instanceof Resource.Classpath) {
-            return fromClasspath((URL) resource.repr(), anchor);
+            try (InputStream stream = resource.asInputStream()) {
+                String data = StringUtil.readFully(stream);
+                return fromSettings(Settings.parse(data, anchor));
+            }
         }
         if (resource instanceof Resource.Filesystem) {
             return fromFile((Path) resource.repr(), anchor);
@@ -945,13 +947,28 @@ public class Config {
          */
         public static class Classpath<T> extends Resource<T> {
             private final URL url;
+            private final ClassLoader loader;
+            private final String resourceName;
 
             Classpath(URL url) {
+                this(url, null, null);
+            }
+
+            Classpath(URL url, ClassLoader loader, String resourceName) {
                 this.url = url;
+                this.loader = loader;
+                this.resourceName = resourceName;
             }
 
             @Override
             public InputStream asInputStream() throws IOException {
+                if (loader != null && resourceName != null) {
+                    InputStream stream = loader.getResourceAsStream(resourceName);
+                    if (stream == null) {
+                        throw new FileNotFoundException(resourceName);
+                    }
+                    return stream;
+                }
                 return url.openStream();
             }
 
@@ -960,7 +977,9 @@ public class Config {
                 if (Objects.equals(url.getProtocol(), "file")) {
                     return MMap.map(url.getPath());
                 }
-                return StringUtil.readAllBytes(url);
+                try (InputStream stream = asInputStream()) {
+                    return StringUtil.readAllBytes(stream);
+                }
             }
 
             @Override
@@ -980,12 +999,13 @@ public class Config {
                 if (o == null || getClass() != o.getClass())
                     return false;
                 Classpath<?> classpath = (Classpath<?>) o;
-                return Objects.equals(url, classpath.url);
+                return Objects.equals(url, classpath.url) && Objects.equals(loader, classpath.loader)
+                        && Objects.equals(resourceName, classpath.resourceName);
             }
 
             @Override
             public int hashCode() {
-                return Objects.hash(url);
+                return Objects.hash(url, loader, resourceName);
             }
         }
 

--- a/src/main/java/com/worksap/nlp/sudachi/DictionaryFactory.java
+++ b/src/main/java/com/worksap/nlp/sudachi/DictionaryFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2022 Works Applications Co., Ltd.
+ * Copyright (c) 2017-2026 Works Applications Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ public class DictionaryFactory {
     @Deprecated()
     public Dictionary create(String settings) throws IOException {
         Config defaults = Config.defaultConfig();
-        Config passed = Config.fromJsonString(settings, PathAnchor.classpath().andThen(PathAnchor.none()));
+        Config passed = Config.fromJsonString(settings, PathAnchor.classpath().andThen(PathAnchor.filesystem()));
         Config merged = passed.withFallback(defaults);
         return create(merged);
     }

--- a/src/main/java/com/worksap/nlp/sudachi/MeCabOovProviderPlugin.java
+++ b/src/main/java/com/worksap/nlp/sudachi/MeCabOovProviderPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Works Applications Co., Ltd.
+ * Copyright (c) 2021-2026 Works Applications Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Paths;
 import java.util.*;
 import java.util.regex.Pattern;
 
@@ -134,7 +133,7 @@ class MeCabOovProviderPlugin extends OovProviderPlugin {
 
     <T> void readCharacterProperty(Config.Resource<T> charDef) throws IOException {
         if (charDef == null) {
-            charDef = settings.base.toResource(Paths.get("char.def"));
+            charDef = settings.base.toResource(settings.base.resolve("char.def"));
         }
         try (InputStream input = charDef.asInputStream();
                 InputStreamReader isReader = new InputStreamReader(input, StandardCharsets.UTF_8);
@@ -170,7 +169,7 @@ class MeCabOovProviderPlugin extends OovProviderPlugin {
 
     <T> void readOOV(Config.Resource<T> unkDef, Grammar grammar, String userPosMode) throws IOException {
         if (unkDef == null) {
-            unkDef = settings.base.toResource(Paths.get("unk.def"));
+            unkDef = settings.base.toResource(settings.base.resolve("unk.def"));
         }
         try (InputStream input = unkDef.asInputStream();
                 InputStreamReader isReader = new InputStreamReader(input, StandardCharsets.UTF_8);

--- a/src/main/java/com/worksap/nlp/sudachi/MeCabOovProviderPlugin.java
+++ b/src/main/java/com/worksap/nlp/sudachi/MeCabOovProviderPlugin.java
@@ -133,7 +133,7 @@ class MeCabOovProviderPlugin extends OovProviderPlugin {
 
     <T> void readCharacterProperty(Config.Resource<T> charDef) throws IOException {
         if (charDef == null) {
-            charDef = settings.base.toResource(settings.base.resolve("char.def"));
+            charDef = settings.base.resource("char.def");
         }
         try (InputStream input = charDef.asInputStream();
                 InputStreamReader isReader = new InputStreamReader(input, StandardCharsets.UTF_8);
@@ -169,7 +169,7 @@ class MeCabOovProviderPlugin extends OovProviderPlugin {
 
     <T> void readOOV(Config.Resource<T> unkDef, Grammar grammar, String userPosMode) throws IOException {
         if (unkDef == null) {
-            unkDef = settings.base.toResource(settings.base.resolve("unk.def"));
+            unkDef = settings.base.resource("unk.def");
         }
         try (InputStream input = unkDef.asInputStream();
                 InputStreamReader isReader = new InputStreamReader(input, StandardCharsets.UTF_8);

--- a/src/main/java/com/worksap/nlp/sudachi/PathAnchor.java
+++ b/src/main/java/com/worksap/nlp/sudachi/PathAnchor.java
@@ -173,6 +173,12 @@ public abstract class PathAnchor {
 
     /**
      * Create a resource for the fully resolved path
+     *
+     * For chained anchors, this method may behave differently from
+     * {@code resource(part)} when passed a path returned by {@code resolve(part)}.
+     * Another child anchor may accept the already resolved path and reinterpret it
+     * through a different base. Use {@link #resource(String)} when resolution and
+     * resource lookup must stay on the same child anchor.
      * 
      * @param path
      *            fully resolved path
@@ -189,6 +195,9 @@ public abstract class PathAnchor {
 
     /**
      * Create a resource for passed string path
+     * 
+     * This is the preferred API for chained anchors because the same child anchor
+     * performs both resolution and resource lookup.
      * 
      * @param path
      *            path to the resource
@@ -373,6 +382,8 @@ public abstract class PathAnchor {
 
         @Override
         public <T> Config.Resource<T> toResource(Path path) {
+            // Note: Another child may also accept an already-resolved path and
+            // reinterpret it through a different base.
             for (PathAnchor child : children) {
                 if (child.exists(path)) {
                     return child.toResource(path);
@@ -380,6 +391,21 @@ public abstract class PathAnchor {
             }
 
             return new Config.Resource.NotFound<>(path, this);
+        }
+
+        @Override
+        public <T> Config.Resource<T> resource(String path) {
+            Path lastPath = null;
+            for (PathAnchor child : children) {
+                Path resolved = child.resolve(path);
+                lastPath = resolved;
+                if (child.exists(resolved)) {
+                    return child.toResource(resolved);
+                }
+                logger.fine(() -> String.format("%s: %s does not exist, skipping", child, path));
+            }
+
+            return new Config.Resource.NotFound<>(lastPath == null ? Paths.get(path) : lastPath, this);
         }
 
         @Override

--- a/src/main/java/com/worksap/nlp/sudachi/PathAnchor.java
+++ b/src/main/java/com/worksap/nlp/sudachi/PathAnchor.java
@@ -300,11 +300,12 @@ public abstract class PathAnchor {
 
         @Override
         public <T> Config.Resource<T> toResource(Path path) {
-            URL resource = loader.getResource(resourceName(path));
+            String name = resourceName(path);
+            URL resource = loader.getResource(name);
             if (resource == null) {
                 return new Config.Resource.NotFound<>(path, this);
             }
-            return new Config.Resource.Classpath<>(resource);
+            return new Config.Resource.Classpath<>(resource, loader, name);
         }
 
         @Override

--- a/src/main/java/com/worksap/nlp/sudachi/PathAnchor.java
+++ b/src/main/java/com/worksap/nlp/sudachi/PathAnchor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2022 Works Applications Co., Ltd.
+ * Copyright (c) 2017-2026 Works Applications Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,13 +34,13 @@ import java.util.logging.Logger;
  * <p>
  * There are three types of anchors:
  * <ul>
- * <li>{@link None} which will resolve paths as filesystem, relative to the
- * CWD</li>
+ * <li>{@link None} which will not search for resources</li>
  * <li>{@link Filesystem} which will resolve paths relative to a provided
  * directory</li>
  * <li>{@link Classpath} which will resolve classpath resources</li>
  * </ul>
- * Use static methods for their creation.
+ * Use static methods for their creation. To resolve paths relative to the
+ * current working directory, use {@link #filesystem()}.
  * <p>
  * One more utility of this class is to capture multiple classloaders in case of
  * complex environment with multiple classloaders (e.g. ElasticSearch plugins).
@@ -128,9 +128,18 @@ public abstract class PathAnchor {
     }
 
     /**
-     * Create a filesystem anchor relative to the current directory
+     * Create a filesystem anchor relative to the current working directory
      * 
      * @return filesystem anchor
+     */
+    public static PathAnchor filesystem() {
+        return filesystem("");
+    }
+
+    /**
+     * Create an anchor which does not search for resources
+     * 
+     * @return non-searching anchor
      */
     public static PathAnchor none() {
         return None.INSTANCE;
@@ -203,6 +212,12 @@ public abstract class PathAnchor {
     public PathAnchor andThen(PathAnchor other) {
         if (this.equals(other)) {
             return this;
+        }
+        if (other instanceof None) {
+            return this;
+        }
+        if (this instanceof None) {
+            return other;
         }
         return new Chain(this, other);
     }
@@ -412,6 +427,16 @@ public abstract class PathAnchor {
         }
 
         private static final None INSTANCE = new None();
+
+        @Override
+        public boolean exists(Path path) {
+            return false;
+        }
+
+        @Override
+        public <T> Config.Resource<T> toResource(Path path) {
+            return new Config.Resource.NotFound<>(path, this);
+        }
 
         @Override
         public String toString() {

--- a/src/main/java/com/worksap/nlp/sudachi/Settings.java
+++ b/src/main/java/com/worksap/nlp/sudachi/Settings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2022 Works Applications Co., Ltd.
+ * Copyright (c) 2017-2026 Works Applications Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -161,7 +161,7 @@ public class Settings {
      */
     @Deprecated
     public static Settings parseSettings(String path, String json) {
-        PathAnchor anchor = path == null ? PathAnchor.none() : PathAnchor.filesystem(Paths.get(path));
+        PathAnchor anchor = path == null ? PathAnchor.filesystem() : PathAnchor.filesystem(Paths.get(path));
         anchor = anchor.andThen(PathAnchor.classpath());
         return parse(json, anchor);
     }
@@ -193,7 +193,7 @@ public class Settings {
                     }
                     return new Settings(root, resolver);
                 } else {
-                    PathAnchor pathResolver = PathAnchor.filesystem(Paths.get(basePath));
+                    PathAnchor pathResolver = PathAnchor.filesystem(basePath);
                     if (resolver != null) {
                         pathResolver = pathResolver.andThen(resolver);
                     }

--- a/src/main/java/com/worksap/nlp/sudachi/Settings.java
+++ b/src/main/java/com/worksap/nlp/sudachi/Settings.java
@@ -461,8 +461,7 @@ public class Settings {
     }
 
     private <T> Config.Resource<T> extractResource(String path) {
-        Path obj = base.resolve(path);
-        return base.toResource(obj);
+        return base.resource(path);
     }
 
     /**

--- a/src/main/java/com/worksap/nlp/sudachi/SudachiCommandLine.java
+++ b/src/main/java/com/worksap/nlp/sudachi/SudachiCommandLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2022 Works Applications Co., Ltd.
+ * Copyright (c) 2017-2026 Works Applications Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -192,7 +192,7 @@ public class SudachiCommandLine {
         }
 
         Tokenizer.SplitMode mode = Tokenizer.SplitMode.C;
-        PathAnchor anchor = PathAnchor.classpath().andThen(PathAnchor.none());
+        PathAnchor anchor = PathAnchor.classpath().andThen(PathAnchor.filesystem());
         Settings current = Settings.resolvedBy(anchor)
                 .read(SudachiCommandLine.class.getClassLoader().getResource("sudachi.json"));
         Config additional = Config.empty();

--- a/src/test/java/com/worksap/nlp/sudachi/ConfigTest.kt
+++ b/src/test/java/com/worksap/nlp/sudachi/ConfigTest.kt
@@ -145,7 +145,7 @@ class ConfigTest {
   fun anchoredWith() {
     val cfg = Config.empty()
     cfg.anchoredWith(PathAnchor.filesystem("test"))
-    assertIs<PathAnchor.Chain>(cfg.anchor)
+    assertIs<PathAnchor.Filesystem>(cfg.anchor)
   }
 
   @Test

--- a/src/test/java/com/worksap/nlp/sudachi/DefaultInputTextPluginTest.java
+++ b/src/test/java/com/worksap/nlp/sudachi/DefaultInputTextPluginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2022 Works Applications Co., Ltd.
+ * Copyright (c) 2017-2026 Works Applications Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ public class DefaultInputTextPluginTest {
         plugin = new DefaultInputTextPlugin();
         try {
             PathAnchor anchor = PathAnchor.classpath();
-            plugin.rewriteDef = anchor.toResource(anchor.resolve("rewrite.def"));
+            plugin.rewriteDef = anchor.resource("rewrite.def");
             plugin.setUp(new MockGrammar());
         } catch (IOException ex) {
             ex.printStackTrace();
@@ -112,7 +112,7 @@ public class DefaultInputTextPluginTest {
     public void invalidFormatOfIgnoreList() throws IOException {
         plugin = new DefaultInputTextPlugin();
         PathAnchor anchor = PathAnchor.classpath();
-        plugin.rewriteDef = anchor.toResource(anchor.resolve("rewrite_error_ignorelist.def"));
+        plugin.rewriteDef = anchor.resource("rewrite_error_ignorelist.def");
         plugin.setUp(new MockGrammar());
     }
 
@@ -120,7 +120,7 @@ public class DefaultInputTextPluginTest {
     public void invalidFormatOfReplaceList() throws IOException {
         plugin = new DefaultInputTextPlugin();
         PathAnchor anchor = PathAnchor.classpath();
-        plugin.rewriteDef = anchor.toResource(anchor.resolve("rewrite_error_replacelist.def"));
+        plugin.rewriteDef = anchor.resource("rewrite_error_replacelist.def");
         plugin.setUp(new MockGrammar());
     }
 
@@ -128,7 +128,7 @@ public class DefaultInputTextPluginTest {
     public void duplicatedLinesInReplaceList() throws IOException {
         plugin = new DefaultInputTextPlugin();
         PathAnchor anchor = PathAnchor.classpath();
-        plugin.rewriteDef = anchor.toResource(anchor.resolve("rewrite_error_dup.def"));
+        plugin.rewriteDef = anchor.resource("rewrite_error_dup.def");
         plugin.setUp(new MockGrammar());
     }
 }

--- a/src/test/java/com/worksap/nlp/sudachi/PathAnchorTest.kt
+++ b/src/test/java/com/worksap/nlp/sudachi/PathAnchorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2022 Works Applications Co., Ltd.
+ * Copyright (c) 2017-2026 Works Applications Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,13 +39,15 @@ class PathAnchorTest {
 
   @Test
   fun chainNone() {
+    val classpath = PathAnchor.classpath()
     assertEquals(PathAnchor.none(), PathAnchor.none().andThen(PathAnchor.none()))
-    assertEquals(PathAnchor.classpath(), PathAnchor.classpath().andThen(PathAnchor.classpath()))
+    assertEquals(classpath, classpath.andThen(classpath))
+    assertSame(classpath, PathAnchor.none().andThen(classpath))
   }
 
   @Test
   fun chain() {
-    val chain = PathAnchor.classpath().andThen(PathAnchor.none())
+    val chain = PathAnchor.classpath().andThen(PathAnchor.filesystem())
     assertIs<PathAnchor.Chain>(chain)
     assertEquals(chain.count(), 2)
     val chain2 = chain.andThen(chain)
@@ -54,8 +56,8 @@ class PathAnchorTest {
 
   @Test
   fun chainChains() {
-    val chain1 = PathAnchor.classpath().andThen(PathAnchor.none())
-    val chain2 = PathAnchor.classpath().andThen(PathAnchor.none())
+    val chain1 = PathAnchor.classpath().andThen(PathAnchor.filesystem())
+    val chain2 = PathAnchor.classpath().andThen(PathAnchor.filesystem())
     val chain3 = chain1.andThen(chain2)
     assertIs<PathAnchor.Chain>(chain3)
     assertEquals(chain3.count(), 2)
@@ -63,8 +65,8 @@ class PathAnchorTest {
 
   @Test
   fun chainChains2() {
-    val chain1 = PathAnchor.classpath().andThen(PathAnchor.filesystem(Paths.get("")))
-    val chain3 = PathAnchor.none().andThen(chain1)
+    val chain1 = PathAnchor.classpath().andThen(PathAnchor.filesystem())
+    val chain3 = PathAnchor.filesystem("another").andThen(chain1)
     assertIs<PathAnchor.Chain>(chain3)
     assertEquals(chain3.count(), 3)
   }
@@ -87,6 +89,20 @@ class PathAnchorTest {
             .andThen(PathAnchor.none())
     assertNotEquals(a.hashCode(), PathAnchor.none().hashCode())
     assertNotEquals(a, PathAnchor.none())
+  }
+
+  @Test
+  fun noneNeverResolves() {
+    val a = PathAnchor.none()
+    assertIs<Resource.NotFound<*>>(a.resource<Any>("char.def"))
+    assertIs<Resource.NotFound<*>>(a.toResource<Any>(Paths.get(".gitignore")))
+  }
+
+  @Test
+  fun filesystemEmptyUsesCurrentDirectory() {
+    val a = PathAnchor.filesystem()
+    assertTrue(a.exists(a.resolve(".gitignore")))
+    assertIsNot<Resource.NotFound<*>>(a.resource<Any>(".gitignore"))
   }
 
   @Test

--- a/src/test/java/com/worksap/nlp/sudachi/PathAnchorTest.kt
+++ b/src/test/java/com/worksap/nlp/sudachi/PathAnchorTest.kt
@@ -18,6 +18,7 @@ package com.worksap.nlp.sudachi
 
 import com.worksap.nlp.sudachi.Config.Resource
 import com.worksap.nlp.sudachi.dictionary.build.DicBuilder
+import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 import kotlin.test.*
@@ -135,5 +136,25 @@ class PathAnchorTest {
     val x = assertIs<Resource.NotFound<*>>(a.toResource<Any>(Paths.get("char.def2")))
     assertFails { x.asByteBuffer() }
     assertFails { x.asInputStream() }
+  }
+
+  @Test
+  fun chainResourceUsesResolvingChildAnchor() {
+    val shadowDir = Paths.get("joinnumeric")
+    val shadowFile = shadowDir.resolve("char.def")
+    Files.createDirectories(shadowDir)
+    Files.write(shadowFile, byteArrayOf())
+    try {
+      val anchor =
+          PathAnchor.filesystem(Paths.get("missing-base"))
+              .andThen(PathAnchor.classpath("joinnumeric", javaClass.classLoader))
+
+      val resource = anchor.resource<Any>("char.def")
+
+      assertIs<Resource.Classpath<*>>(resource)
+    } finally {
+      Files.deleteIfExists(shadowFile)
+      Files.deleteIfExists(shadowDir)
+    }
   }
 }


### PR DESCRIPTION
Current `PathAnchor` tries to see files during the resolution and it makes elasticsearch (v8.18+) cause entitlement error.

This PR includes:
- let `PathAnchor.Classpath` loads data via class loader, instead of URL.
  - This causes the problem in elasticsearch
- make `PathAnchor.None` does nothing, instead of searching CWD.
  - to search CWD, filesystem() should be used.
- new implementation for `PathAnchor.Chain.resource` which always uses correct child anchor.
