### PR TITLE
Pre/0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 -
 
+## [v0.8.0](https://github.com/WorksApplications/Sudachi/releases/tag/v0.8.0)
+
+> **CAUTION**
+> This release is unstable. It may include breaking changes even between patch versions, so please pin the exact version and review release notes carefully before upgrading.
+
+### Changed
+
+- `PathAnchor.None` does NOT resolve now (#361).
+- 0-th column of DictionaryPrinter output become normalized (#242).
+
+### Added
+
+- Add TextNormalizer (#242)
+
+
 ## [v0.7.5](https://github.com/WorksApplications/Sudachi/releases/tag/v0.7.5)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ mainly of the following tasks.
 - Part-of-speech tagging
 - Normalization
 
+> **CAUTION**
+> This release is unstable. It may include breaking changes even between patch versions, so please pin the exact version and review release notes carefully before upgrading.
+
 ## Tutorial
 
 For a tutorial on installation, please refer to the [tutorial page](/docs/tutorial.md).

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 }
 
 group = 'com.worksap.nlp'
-version = '0.7.6-SNAPSHOT'
+version = '0.8.0'
 description = 'Sudachi Japanese Morphological Analyzer'
 java.sourceCompatibility = JavaVersion.VERSION_1_8
 


### PR DESCRIPTION
PR for v0.8.0 release.

This version (v0.8) will be unstable and we may change API even between patch versions.
- we are planning to update dictionary version to V1.
