### PR TITLE
update url for publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,8 +3,8 @@ on:
   push:
     branches:
       - develop
-  pull_request: # uncommit for debug
-      types: [ opened, synchronize, reopened ]
+#  pull_request: # uncommit for debug
+#      types: [ opened, synchronize, reopened ]
 
 jobs:
   publish:
@@ -28,5 +28,5 @@ jobs:
           MAVEN_USER_PASSWORD: ${{ secrets.MAVEN_USER_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
           MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-        run: ./gradlew --no-daemon --info --stacktrace publishToSonatype closeAndReleaseSonatypeStagingRepository
+        run: ./gradlew --no-daemon --info --stacktrace publish publishToSonatype closeAndReleaseSonatypeStagingRepository
         if: env.MAVEN_USERNAME != ''

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,5 +28,5 @@ jobs:
           MAVEN_USER_PASSWORD: ${{ secrets.MAVEN_USER_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
           MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-        run: ./gradlew --no-daemon --info --stacktrace publish publishToSonatype closeAndReleaseSonatypeStagingRepository
+        run: ./gradlew --no-daemon --info --stacktrace publishToSonatype closeAndReleaseSonatypeStagingRepository
         if: env.MAVEN_USERNAME != ''

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,8 +3,8 @@ on:
   push:
     branches:
       - develop
-#  pull_request: # uncommit for debug
-#      types: [ opened, synchronize, reopened ]
+  pull_request: # uncommit for debug
+      types: [ opened, synchronize, reopened ]
 
 jobs:
   publish:

--- a/build.gradle
+++ b/build.gradle
@@ -181,6 +181,8 @@ publishing {
 nexusPublishing {
     repositories {
         sonatype {
+            nexusUrl = uri("https://ossrh-staging-api.central.sonatype.com/service/local/")
+            snapshotRepositoryUrl = uri("https://central.sonatype.com/repository/maven-snapshots/")
             username = project.findProperty("maven.user") ?: System.getenv("MAVEN_USERNAME")
             password = project.findProperty("maven.password") ?: System.getenv("MAVEN_USER_PASSWORD")
         }

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
     id 'distribution'
     id 'signing'
     id 'me.champeau.jmh' version "0.6.6"
-    id 'io.github.gradle-nexus.publish-plugin' version "1.1.0"
+    id 'io.github.gradle-nexus.publish-plugin' version "2.0.0"
 }
 
 repositories {


### PR DESCRIPTION
the current publication had reached its EOL (2025): https://central.sonatype.org/pages/ossrh-eol/

we need to:
- set new URL to gradle plugin
  - https://github.com/gradle-nexus/publish-plugin/#publishing-to-maven-central-via-sonatype-central
- update credential for new API (https://central.sonatype.org/publish/generate-portal-token/)
