### PR TITLE
Add cli option to print reading form

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,23 +31,30 @@ jobs:
           distribution: temurin
           cache: gradle
       - name: Cache SonarCloud packages
-        if: matrix.java-version >= 17
+        if: matrix.java-version == 17
         uses: actions/cache@v5
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
       - name: Build and check
         run: ./gradlew --no-daemon --info --stacktrace build jacocoTestReport
+      - name: Build javadoc
+        run: ./gradlew --no-daemon --info javadoc
+
+      - name: Set up JDK 21 for Sonar
+        if: matrix.java-version == 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
       - name: Analyze with sonarqube
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        if: matrix.java-version >= 17 && env.SONAR_TOKEN != ''
+        if: matrix.java-version == 17 && env.SONAR_TOKEN != ''
         run: ./gradlew --no-daemon --info --stacktrace sonarqube -Dsonar.verbose=true -Dsonar.login=$SONAR_TOKEN
       - uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: reports (${{ matrix.java-version }})
           path: build/reports
-      - name: Build javadoc
-        run: ./gradlew --no-daemon --info javadoc

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ $ java -jar sudachi-XX.jar -s '{"systemDict":"system_small.dic"}'
 ## Use on the command line
 
 ```
-$ java -jar sudachi-XX.jar [-r conf] [-s json] [-m mode] [-a] [-d] [-f] [-o output] [file...]
+$ java -jar sudachi-XX.jar [-r conf] [-s json] [-m mode] [-a] [--print-reading] [-d] [-f] [-o output] [file...]
 ```
 
 ### Options
@@ -75,6 +75,7 @@ $ java -jar sudachi-XX.jar [-r conf] [-s json] [-m mode] [-a] [-d] [-f] [-o outp
 - `-p directory` root directory of resources
 - `-m {A|B|C}` specifies the mode of splitting
 - `-a` outputs the dictionary form, the reading form, the dictionary id, the synonym group id list, and OOV flag.
+- `--print-reading` outputs the reading form. If combined with `-a`, `-a` takes precedence.
 - `-d` dump the debug outputs
 - `-o file` specifies output file (default: the standard output)
 - `-t` separate words with spaces
@@ -96,6 +97,12 @@ $ java -jar sudachi-XX.jar [-r conf] [-s json] [-m mode] [-a] [-d] [-f] [-o outp
     東京都  名詞,固有名詞,地名,一般,*,*     東京都  東京都  トウキョウト    0       []
     へ      助詞,格助詞,*,*,*,*     へ      へ      ヘ      0       []
     行く    動詞,非自立可能,*,*,五段-カ行,終止形-一般       行く    行く    イク    0       []
+    EOS
+
+    $ echo 東京都へ行く | java -jar target/sudachi.jar --print-reading
+    東京都  名詞,固有名詞,地名,一般,*,*     東京都  トウキョウト
+    へ      助詞,格助詞,*,*,*,*     へ      ヘ
+    行く    動詞,非自立可能,*,*,五段-カ行,終止形-一般       行く    イク
     EOS
 
     $ echo 東京都へ行く | java -jar target/sudachi.jar -m A
@@ -400,7 +407,7 @@ $ java -jar sudachi-XX.jar -s '{"systemDict":"system_small.dic"}'
 ## コマンドラインツール
 
 ```
-$ java -jar sudachi-XX.jar [-r conf] [-s json] [-m mode] [-a] [-d] [-f] [-o output] [file...]
+$ java -jar sudachi-XX.jar [-r conf] [-s json] [-m mode] [-a] [--print-reading] [-d] [-f] [-o output] [file...]
 ```
 
 ### オプション
@@ -410,6 +417,7 @@ $ java -jar sudachi-XX.jar [-r conf] [-s json] [-m mode] [-a] [-d] [-f] [-o outp
 - -p directory リソースの起点となるディレクトリを指定
 - -m {A|B|C} 分割モード
 - -a 追加で辞書形、読み、辞書ID、同義語グループID、OOV フラグを出力
+- --print-reading 表層形、品詞、正規化表記、読みを出力。辞書更新による解析結果の比較に適した形式。-a と同時に指定した場合は -a を優先
 - -d デバッグ情報の出力
 - -o 出力ファイル (指定がない場合は標準出力)
 - -t 単語をスペース区切りで出力
@@ -428,6 +436,12 @@ $ java -jar sudachi-XX.jar [-r conf] [-s json] [-m mode] [-a] [-d] [-f] [-o outp
     東京都  名詞,固有名詞,地名,一般,*,*     東京都  東京都  トウキョウト    0       []
     へ      助詞,格助詞,*,*,*,*     へ      へ      ヘ      0       []
     行く    動詞,非自立可能,*,*,五段-カ行,終止形-一般       行く    行く    イク    0       []
+    EOS
+
+    $ echo 東京都へ行く | java -jar target/sudachi.jar --print-reading
+    東京都  名詞,固有名詞,地名,一般,*,*     東京都  トウキョウト
+    へ      助詞,格助詞,*,*,*,*     へ      ヘ
+    行く    動詞,非自立可能,*,*,五段-カ行,終止形-一般       行く    イク
     EOS
 
     $ echo 東京都へ行く | java -jar target/sudachi.jar -m A

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ $ java -jar sudachi-XX.jar -s '{"systemDict":"system_small.dic"}'
 ## Use on the command line
 
 ```
-$ java -jar sudachi-XX.jar [-r conf] [-s json] [-m mode] [-a] [--print-reading] [-d] [-f] [-o output] [file...]
+$ java -jar sudachi-XX.jar [-r conf] [-s json] [-p directory] [-m mode] [-o output] [-t|-ts] [-a] [--print-reading] [-f] [-d] [--systemDict file] [--userDict file] [--format class] [file...]
 ```
 
 ### Options
@@ -74,13 +74,13 @@ $ java -jar sudachi-XX.jar [-r conf] [-s json] [-m mode] [-a] [--print-reading] 
 - `-s json` additional settings (overrides -r)
 - `-p directory` root directory of resources
 - `-m {A|B|C}` specifies the mode of splitting
-- `-a` outputs the dictionary form, the reading form, the dictionary id, the synonym group id list, and OOV flag.
-- `--print-reading` outputs the reading form. If combined with `-a`, `-a` takes precedence.
-- `-d` dump the debug outputs
 - `-o file` specifies output file (default: the standard output)
 - `-t` separate words with spaces
 - `-ts` separate words with spaces, and break line for each sentence
+- `-a` outputs the dictionary form, the reading form, the dictionary id, the synonym group id list, and OOV flag.
+- `--print-reading` outputs the reading form. If combined with `-a`, `-a` takes precedence.
 - `-f` ignore errors
+- `-d` dump the debug outputs
 - `--systemDict file` specify path to the system dictionary. Will override other settings.
 - `--userDict file` add a user dictionary. Will not override other settings, but add another user dictionary.
 - `--format class` use the provided class for formatting output instead of default configuration
@@ -407,22 +407,25 @@ $ java -jar sudachi-XX.jar -s '{"systemDict":"system_small.dic"}'
 ## コマンドラインツール
 
 ```
-$ java -jar sudachi-XX.jar [-r conf] [-s json] [-m mode] [-a] [--print-reading] [-d] [-f] [-o output] [file...]
+$ java -jar sudachi-XX.jar [-r conf] [-s json] [-p directory] [-m mode] [-o output] [-t|-ts] [-a] [--print-reading] [-f] [-d] [--systemDict file] [--userDict file] [--format class] [file...]
 ```
 
 ### オプション
 
-- -r conf 設定ファイルを指定 (-s と排他)
-- -s json デフォルト設定の上書き (-r と排他)
-- -p directory リソースの起点となるディレクトリを指定
-- -m {A|B|C} 分割モード
-- -a 追加で辞書形、読み、辞書ID、同義語グループID、OOV フラグを出力
-- --print-reading 表層形、品詞、正規化表記、読みを出力。辞書更新による解析結果の比較に適した形式。-a と同時に指定した場合は -a を優先
-- -d デバッグ情報の出力
-- -o 出力ファイル (指定がない場合は標準出力)
-- -t 単語をスペース区切りで出力
-- -ts 単語をスペース区切りで出力、文末で改行を出力
-- -f エラーを無視して処理を続行する
+- `-r conf` 設定ファイルを指定 (-s と排他)
+- `-s json` デフォルト設定の上書き (-r と排他)
+- `-p directory` リソースの起点となるディレクトリを指定
+- `-m {A|B|C}` 分割モード
+- `-o` 出力ファイル (指定がない場合は標準出力)
+- `-t` 単語をスペース区切りで出力
+- `-ts` 単語をスペース区切りで出力、文末で改行を出力
+- `-a` 追加で辞書形、読み、辞書ID、同義語グループID、OOV フラグを出力
+- `--print-reading` 追加で読みを出力。-a と同時に指定した場合は -a を優先
+- `-f` エラーを無視して処理を続行する
+- `-d` デバッグ情報の出力
+- `--systemDict file` システム辞書バイナリを指定。他のオプションを上書きする
+- `--userDict file` ユーザ辞書バイナリを追加する。他のオプションでの指定に対して追加される
+- `--format class` 出力のフォーマットに使用する Java クラスを指定する
 
 ### 出力例
 

--- a/src/main/java/com/worksap/nlp/sudachi/SimpleMorphemeFormatter.java
+++ b/src/main/java/com/worksap/nlp/sudachi/SimpleMorphemeFormatter.java
@@ -43,11 +43,13 @@ import java.util.Arrays;
 public class SimpleMorphemeFormatter extends MorphemeFormatterPlugin {
 
     protected String columnDelimiter;
+    private boolean printReading;
 
     @Override
     public void setUp() throws IOException {
         super.setUp();
         columnDelimiter = settings.getString("columnDelimiter", "\t");
+        printReading = false;
     }
 
     @Override
@@ -59,7 +61,13 @@ public class SimpleMorphemeFormatter extends MorphemeFormatterPlugin {
                     + columnDelimiter + morpheme.getDictionaryId() + columnDelimiter
                     + Arrays.toString(morpheme.getSynonymGroupIds()) + columnDelimiter
                     + ((morpheme.isOOV()) ? "(OOV)" : "");
+        } else if (printReading) {
+            output += columnDelimiter + morpheme.readingForm();
         }
         return output;
+    }
+
+    public void setPrintReading(boolean printReading) {
+        this.printReading = printReading;
     }
 }

--- a/src/main/java/com/worksap/nlp/sudachi/SudachiCommandLine.java
+++ b/src/main/java/com/worksap/nlp/sudachi/SudachiCommandLine.java
@@ -137,7 +137,7 @@ public class SudachiCommandLine {
      *
      * <p>
      * Usage:
-     * {@code SudachiCommandLine [-r file] [-m A|B|C] [-o file] [-d] [file ...]}
+     * {@code SudachiCommandLine [-r conf] [-s json] [-p directory] [-m mode] [-o output] [-t|-ts] [-a] [--print-reading] [-f] [-d] [--systemDict file] [--userDict file] [--format class] [file...]}
      * <p>
      * The following are the options.
      * <dl>
@@ -145,6 +145,8 @@ public class SudachiCommandLine {
      * <dd>the settings file in JSON format (overrides -s)</dd>
      * <dt>{@code -s string}</dt>
      * <dd>an additional settings string in JSON format (overrides -r)</dd>
+     * <dt>{@code -p directory}</dt>
+     * <dd>a root directory for the resource files</dd>
      * <dt>{@code -m {A|B|C}}</dt>
      * <dd>the mode of splitting</dd>
      * <dt>{@code -o file}</dt>
@@ -157,8 +159,16 @@ public class SudachiCommandLine {
      * <dd>show details</dd>
      * <dt>{@code --print-reading}</dt>
      * <dd>show the reading form in addition to the default fields</dd>
+     * <dt>{@code -f}</dt>
+     * <dd>ignore errors</dd>
      * <dt>{@code -d}</dt>
      * <dd>print the debug informations</dd>
+     * <dt>{@code --systemDict file}</dt>
+     * <dd>path to a system dictionary (overrides everything)</dd>
+     * <dt>{@code --userDict file}</dt>
+     * <dd>path to an additional user dictionary (appended to -s)</dd>
+     * <dt>{@code --format class}</dt>
+     * <dd>format class for output</dd>
      * <dt>{@code -h}</dt>
      * <dd>show the usage</dd>
      * </dl>
@@ -256,7 +266,8 @@ public class SudachiCommandLine {
                 isLineBreakAtEosInWordSegmentation = true;
             } else if (args[i].equals("-h")) {
                 PrintStream stderr = System.err;
-                stderr.print("usage: SudachiCommandLine [-r file] [-m A|B|C] [-o file] [file ...]\n");
+                stderr.print(
+                        "usage: SudachiCommandLine [-r conf] [-s json] [-p directory] [-m mode] [-o output] [-t|-ts] [-a] [--print-reading] [-f] [-d] [--systemDict file] [--userDict file] [--format class] [file...]\n");
                 stderr.print("\t-r file\tread settings from file (overrides -s)\n");
                 stderr.print("\t-s string\tadditional settings (overrides -r)\n");
                 stderr.print("\t-p directory\troot directory of resources\n");
@@ -266,10 +277,11 @@ public class SudachiCommandLine {
                 stderr.print("\t-ts\tseparate words with spaces, and break line for each sentence\n");
                 stderr.print("\t-a\tshow details\n");
                 stderr.print("\t--print-reading\tshow the reading form in addition to the default fields\n");
-                stderr.print("\t-f\tignore error\n");
+                stderr.print("\t-f\tignore errors\n");
                 stderr.print("\t-d\tdebug mode\n");
                 stderr.print("\t--systemDict file\tpath to a system dictionary (overrides everything)\n");
                 stderr.print("\t--userDict file\tpath to an additional user dictionary (appended to -s)\n");
+                stderr.print("\t--format class\tformat class for output\n");
                 return;
             } else if (args[i].equals("--userDict")) {
                 Path resolved = anchor.resolve(args[++i]);

--- a/src/main/java/com/worksap/nlp/sudachi/SudachiCommandLine.java
+++ b/src/main/java/com/worksap/nlp/sudachi/SudachiCommandLine.java
@@ -155,6 +155,8 @@ public class SudachiCommandLine {
      * <dd>separate words with spaces, and break line for each sentence</dd>
      * <dt>{@code -a}</dt>
      * <dd>show details</dd>
+     * <dt>{@code --print-reading}</dt>
+     * <dd>show the reading form in addition to the default fields</dd>
      * <dt>{@code -d}</dt>
      * <dd>print the debug informations</dd>
      * <dt>{@code -h}</dt>
@@ -200,6 +202,7 @@ public class SudachiCommandLine {
         String outputFileName = null;
         boolean isEnableDump = false;
         boolean showDetails = false;
+        boolean printReading = false;
         boolean ignoreError = false;
         boolean isWordSegmentation = false;
         boolean isLineBreakAtEosInWordSegmentation = true;
@@ -239,6 +242,8 @@ public class SudachiCommandLine {
                 outputFileName = args[++i];
             } else if (args[i].equals("-a")) {
                 showDetails = true;
+            } else if (args[i].equals("--print-reading")) {
+                printReading = true;
             } else if (args[i].equals("-d")) {
                 isEnableDump = true;
             } else if (args[i].equals("-f")) {
@@ -260,6 +265,7 @@ public class SudachiCommandLine {
                 stderr.print("\t-t\tseparate words with spaces\n");
                 stderr.print("\t-ts\tseparate words with spaces, and break line for each sentence\n");
                 stderr.print("\t-a\tshow details\n");
+                stderr.print("\t--print-reading\tshow the reading form in addition to the default fields\n");
                 stderr.print("\t-f\tignore error\n");
                 stderr.print("\t-d\tdebug mode\n");
                 stderr.print("\t--systemDict file\tpath to a system dictionary (overrides everything)\n");
@@ -286,6 +292,8 @@ public class SudachiCommandLine {
                 formatterKind, current);
         if (showDetails) {
             formatter.showDetails();
+        } else if (printReading && formatter instanceof SimpleMorphemeFormatter) {
+            ((SimpleMorphemeFormatter) formatter).setPrintReading(true);
         }
 
         try (PrintStream output = outputFileName == null ? new FileOrStdoutPrintStream()

--- a/src/test/java/com/worksap/nlp/sudachi/SudachiCommandLineTest.java
+++ b/src/test/java/com/worksap/nlp/sudachi/SudachiCommandLineTest.java
@@ -128,6 +128,39 @@ public class SudachiCommandLineTest {
     }
 
     @Test
+    public void commandLineWithPrintReadingOption() throws IOException {
+        SudachiCommandLine.main(
+                new String[] { "-p", temporaryFolderName, "-o", outputFileName, "--print-reading", inputFileName });
+        try (Stream<String> lines = Files.lines(Paths.get(outputFileName))) {
+            Optional<String> first = lines.filter(l -> !l.equals("EOS")).findFirst();
+            assertTrue(first.isPresent());
+            assertThat(first.get().split("\\t"), is(new String[] { "東京都", "名詞,固有名詞,地名,一般,*,*", "東京都", "トウキョウト" }));
+        }
+    }
+
+    @Test
+    public void commandLineWithAOptionBeforePrintReadingOption() throws IOException {
+        SudachiCommandLine.main(new String[] { "-p", temporaryFolderName, "-o", outputFileName, "-a", "--print-reading",
+                inputFileName });
+        try (Stream<String> lines = Files.lines(Paths.get(outputFileName))) {
+            Optional<String> first = lines.filter(l -> !l.equals("EOS")).findFirst();
+            assertTrue(first.isPresent());
+            assertThat(first.get().split("\\t").length, is(7));
+        }
+    }
+
+    @Test
+    public void commandLineWithPrintReadingOptionBeforeAOption() throws IOException {
+        SudachiCommandLine.main(new String[] { "-p", temporaryFolderName, "-o", outputFileName, "--print-reading", "-a",
+                inputFileName });
+        try (Stream<String> lines = Files.lines(Paths.get(outputFileName))) {
+            Optional<String> first = lines.filter(l -> !l.equals("EOS")).findFirst();
+            assertTrue(first.isPresent());
+            assertThat(first.get().split("\\t").length, is(7));
+        }
+    }
+
+    @Test
     public void commandLineWithDOption() throws IOException {
         SudachiCommandLine.main(new String[] { "-p", temporaryFolderName, "-o", outputFileName, "-d", inputFileName });
         try (Stream<String> lines = Files.lines(Paths.get(outputFileName))) {


### PR DESCRIPTION
Add new cli option `--print-reading`.
If it is provided, cli will print the reading form in addition to the surface/pos/normalized_form.

- This option only works with `SimpleMorphemeFormatter` (i.e. using this with different formatter specified by `--format` does nothing)
- when used along with `-a` option, `-a` takes precedence (prints detailed output).

Also update CLI tool usage.